### PR TITLE
Added a LoadMode property to tell MapCache how to load the tiles

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -100,6 +100,8 @@
 		8992A45822A73FF300C186CA /* MKMapView+MapCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8992A45622A73C4700C186CA /* MKMapView+MapCache.swift */; };
 		8992A45E22AF12D800C186CA /* TileCoords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8992A45D22AF12D800C186CA /* TileCoords.swift */; };
 		8992A46122AF307A00C186CA /* TileCoords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8992A45D22AF12D800C186CA /* TileCoords.swift */; };
+		899B378D2466F71000101B13 /* LoadTileMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899B378C2466F71000101B13 /* LoadTileMode.swift */; };
+		899B378E2466FA0700101B13 /* LoadTileMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899B378C2466F71000101B13 /* LoadTileMode.swift */; };
 		89F6E11E228A320700CE3E3F /* CachedTileOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F6E11D228A320700CE3E3F /* CachedTileOverlay.swift */; };
 		89F6E122228A38F700CE3E3F /* MapCacheConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F6E121228A38F700CE3E3F /* MapCacheConfig.swift */; };
 		89F6E124228A3B1B00CE3E3F /* MapCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F6E123228A3B1B00CE3E3F /* MapCache.swift */; };
@@ -284,6 +286,7 @@
 		895E71B422C7F2D10006977C /* MapCacheProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MapCacheProtocol.swift; path = MapCache/Classes/MapCacheProtocol.swift; sourceTree = "<group>"; };
 		8992A45622A73C4700C186CA /* MKMapView+MapCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "MKMapView+MapCache.swift"; path = "MapCache/Classes/MKMapView+MapCache.swift"; sourceTree = "<group>"; };
 		8992A45D22AF12D800C186CA /* TileCoords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TileCoords.swift; path = MapCache/Classes/TileCoords.swift; sourceTree = "<group>"; };
+		899B378C2466F71000101B13 /* LoadTileMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LoadTileMode.swift; path = MapCache/Classes/LoadTileMode.swift; sourceTree = "<group>"; };
 		89F6E11D228A320700CE3E3F /* CachedTileOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CachedTileOverlay.swift; path = MapCache/Classes/CachedTileOverlay.swift; sourceTree = "<group>"; };
 		89F6E121228A38F700CE3E3F /* MapCacheConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MapCacheConfig.swift; path = MapCache/Classes/MapCacheConfig.swift; sourceTree = "<group>"; };
 		89F6E123228A3B1B00CE3E3F /* MapCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MapCache.swift; path = MapCache/Classes/MapCache.swift; sourceTree = "<group>"; };
@@ -715,6 +718,7 @@
 				895E719922B341320006977C /* TileRangeIterator.swift */,
 				895E719B22B34BC30006977C /* ZoomRange.swift */,
 				895E719F22B464AF0006977C /* ZoomRangeIterator.swift */,
+				899B378C2466F71000101B13 /* LoadTileMode.swift */,
 			);
 			name = MapCache;
 			path = ../..;
@@ -926,6 +930,7 @@
 				895E71A622B59E840006977C /* ZoomRange.swift in Sources */,
 				8992A45822A73FF300C186CA /* MKMapView+MapCache.swift in Sources */,
 				893072D122A49724008612A1 /* FileManager+DiskCache.swift in Sources */,
+				899B378E2466FA0700101B13 /* LoadTileMode.swift in Sources */,
 				895E71A922B59E8D0006977C /* TileCoordsRegion.swift in Sources */,
 				895E71A522B59E800006977C /* ZoomRangeIterator.swift in Sources */,
 				893072D622A497B5008612A1 /* MapCacheConfig.swift in Sources */,
@@ -1023,6 +1028,7 @@
 				893072C122A47C76008612A1 /* FileManager+DiskCache.swift in Sources */,
 				89F6E11E228A320700CE3E3F /* CachedTileOverlay.swift in Sources */,
 				895E71AD22B9B2390006977C /* RegionDownloaderDelegate.swift in Sources */,
+				899B378D2466F71000101B13 /* LoadTileMode.swift in Sources */,
 				895E71AF22B9B75A0006977C /* MKTileOverlayPath+MapCache.swift in Sources */,
 				895E71B522C7F2D10006977C /* MapCacheProtocol.swift in Sources */,
 				895E719A22B341320006977C /* TileRangeIterator.swift in Sources */,

--- a/MapCache/Classes/LoadTileMode.swift
+++ b/MapCache/Classes/LoadTileMode.swift
@@ -1,0 +1,31 @@
+//
+//  LoadTileMode.swift
+//  MapCache
+//
+//  Created by merlos on 09/05/2020.
+//
+
+import Foundation
+
+public enum LoadTileMode {
+    
+    /// Default. If the tile exists in the cache, return it, otherwise, fetch it from server (and cache the result)
+    case cacheThenServer
+    
+    /// Always return the tile from the server unless there is some problem with the network
+    /// Cache is updated everytime the tile is received.
+    /// Basically uses the cache as internet connection fallback
+    case serverThenCache
+          
+    /// Only return data from cache
+    /// Useful for fully offline preloaded maps.
+    case cacheOnly
+    
+    /// Always return the tile from the server, as well as updating the cache
+    /// This mode may be useful for donwloading a whole map region
+    /// If a tile was not downloaded fron the server error is returned.
+    case serverOnly
+    
+   
+   
+   }

--- a/MapCache/Classes/MapCache.swift
+++ b/MapCache/Classes/MapCache.swift
@@ -27,7 +27,7 @@ public class MapCache : MapCacheProtocol {
         urlString = urlString.replacingOccurrences(of: "{x}", with: String(path.x))
         urlString = urlString.replacingOccurrences(of: "{y}", with: String(path.y))
         urlString = urlString.replacingOccurrences(of: "{s}", with: config.roundRobinSubdomain() ?? "")
-        print("MapCache::url() urlString: \(urlString)")
+        Log.debug(message: "MapCache::url() urlString: \(urlString)")
         return URL(string: urlString)!
     }
     
@@ -35,51 +35,65 @@ public class MapCache : MapCacheProtocol {
         return "\(config.urlTemplate)-\(path.x)-\(path.y)-\(path.z)"
     }
     
+    
     public func loadTile(at path: MKTileOverlayPath, result: @escaping (Data?, Error?) -> Void) {
-        // Use cache
-        // is the file alread in the system?
+        
         let key = cacheKey(forPath: path)
         
-        let loadTileFromOrigin = { () -> () in
+        // Feches tile from server. If it is found updates the cache
+        func fetchTileFromServer(failure fail: ((Error?) -> ())? = nil,
+                                 success succeed: @escaping (Data) -> ()) {
             let url = self.url(forTilePath: path)
-            print ("MapCache::loadTile() url=\(url)")
+            print ("MapCache::fetchTileFromServer() url=\(url)")
             let task = URLSession.shared.dataTask(with: url) {(data, response, error) in
                 if error != nil {
-                    print("!!! MapCache::loadTile Error for key= \(key)")
-                    result(nil, error)
+                    print("!!! MapCache::fetchTileFromServer Error for url= \(url)")
+                    fail!(error)
                     return
                 }
                 guard let data = data else {
-                    result(nil, nil)
+                    fail!(nil)
                     return
                 }
                 self.diskCache.setData(data, forKey: key)
-                print ("CachedTileOverlay:: Data received saved cacheKey=\(key)" )
-                result(data,nil)
+                print ("MapCache::fetchTileFromServer:: Data received saved cacheKey=\(key)" )
+                succeed(data)
             }
             task.resume()
         }
         
-        // If fetching data from cache is successfull => return the data
-        let fetchSuccess = {(data: Data) -> () in
-            print ("MapCache::loadTile() found! cacheKey=\(key)" )
-            result (data, nil)
-        }
-        // Closure to run if error found while fetching data from cache
-        let fetchFailure = { (error: Error?) -> () in
-            print ("MapCache::loadTile() Not found! cacheKey=\(key)" )
-            loadTileFromOrigin()
+       // Tries to load the tile from the server.
+       // If it fails returns error to the caller.
+        let tileFromServerFallback = { () -> () in
+            print ("MapCache::tileFromServerFallback:: key=\(key)" )
+            fetchTileFromServer(failure: {error in result(nil, error)},
+                                success: {data in result(data, nil)})
         }
         
-        switch mode {
+        // Tries to load the tile from the cache.
+        // If it fails returns error to the caller.
+        let tileFromCacheFallback = { () -> () in
+            self.diskCache.fetchDataSync(forKey: key,
+                    failure: {error in result(nil, error)},
+                    success: {data in result(data, nil)})
             
-            case .always_server:
-                loadTileFromOrigin()
-            case .cache_then_server:
-                diskCache.fetchDataSync(forKey: key, failure: fetchFailure, success: fetchSuccess)
-            case .cache_only:
-                diskCache.fetchDataSync(forKey: key, failure: { error in result(nil, error)}, success: fetchSuccess)
-    
+        }
+        
+        switch config.loadTileMode {
+        case .cacheThenServer:
+            diskCache.fetchDataSync(forKey: key,
+                                    failure: {error in tileFromServerFallback()},
+                                    success: {data in result(data, nil) })
+        case .serverThenCache:
+            fetchTileFromServer(failure: {error in tileFromCacheFallback()},
+                                success: {data in result(data, nil) })
+        case .serverOnly:
+            fetchTileFromServer(failure: {error in result(nil, error)},
+                                success: {data in result(data, nil)})
+        case .cacheOnly:
+            diskCache.fetchDataSync(forKey: key,
+                failure: {error in result(nil, error)},
+                success: {data in result(data, nil)})
         }
     }
     

--- a/MapCache/Classes/MapCache.swift
+++ b/MapCache/Classes/MapCache.swift
@@ -12,23 +12,6 @@ import MapKit
 /// The real brain
 public class MapCache : MapCacheProtocol {
     
-    public enum LoadMode {
-        ///Always return the tile from the server, as well as updating the cache
-        case always_server
-        
-        ///If the tile exists in the cache, return it, otherwise, fetch it from server (and cache the result)
-        case cache_then_server
-
-        ///TODO: If the tile exists in the cache and is younger than a user-supplied setting, return it, otherwise, fetch it from server (and update cache)
-        //case cache_if_expired_then_server
-        
-        ///Only return data from cache
-        case cache_only
-
-    }
-
-    public var mode : LoadMode = .cache_then_server
-
     public var config : MapCacheConfig
     public var diskCache : DiskCache
     let operationQueue = OperationQueue()

--- a/MapCache/Classes/MapCacheConfig.swift
+++ b/MapCache/Classes/MapCacheConfig.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 
 ///
@@ -54,6 +55,12 @@ public struct MapCacheConfig  {
     ///
     public var tileSize: CGSize = CGSize(width: 256, height: 256)
 
+    ///
+    /// Load tile  mode.
+    /// Sets the strategy when loading a tile. By default loads from the cache and if it fails loads from the server
+    ///
+    public var loadTileMode: LoadTileMode = .cacheThenServer
+    
     public init() {
     }
     


### PR DESCRIPTION
Following up on discussion from #17 I did find that using two closures did not seem to work properly. So since you can only select from either server or cache I made this modification.

I was able to make this work for my local fork.  I added a property called LoadMode that determines how `loadTile(at path: MKTileOverlayPath...` loads tiles.  The user could change this mode dynamically depending on their use case, their network connection status, etc.

- **case always_server** always fetches from server, updating cache.  Useful when on unmetered and high bandwidth (eg. Wifi) connection.  User always receives most recent data.

- **case cache_then_server** is the current paradigm. Use the cache, unless not found, then fetch from server and update.  Minimum amount of network access.

- **case cache_if_expired_then_server** returns from cache if the cache file is new enough, otherwise fetch from server and update. This I left as a TODO because a method is needed to first retrieve the file date and compare it to _.now_ minus some user supplied delta. This is useful if the user cares mostly about limiting network access, but will accept some loading of tiles from the server if the cache is too old.

- **case cache_only** Only fetch from cache, never go out to server. Useful to completely eliminate any bandwidth usage (perhaps user is on a limited or expensive data connection - they want to just use their cache which they've presumably loaded up prior).





