### PR TITLE
fix xcode12 dangling pointer warning

### DIFF
--- a/MapCache/Classes/DiskCache/String+DiskCache.swift
+++ b/MapCache/Classes/DiskCache/String+DiskCache.swift
@@ -32,10 +32,8 @@ extension String {
         
         let MD5Calculator = MD5(Array(data))
         let MD5Data = MD5Calculator.calculate()
-        let resultBytes = UnsafeMutablePointer<CUnsignedChar>(mutating: MD5Data)
-        let resultEnumerator = UnsafeBufferPointer<CUnsignedChar>(start: resultBytes, count: MD5Data.count)
         let MD5String = NSMutableString()
-        for c in resultEnumerator {
+        for c in MD5Data {
             MD5String.appendFormat("%02x", c)
         }
         return MD5String as String


### PR DESCRIPTION
Xcode12 gives a "Dangling Pointer" warning in ../Classes/DiskCache/String+DiskCache.swift . I fixed it by a small code change and removing redundant code.