### PR TITLE
Fix broken insert overlay for iOS 16

### DIFF
--- a/MapCache.podspec
+++ b/MapCache.podspec
@@ -28,7 +28,7 @@ DESC
 
   s.swift_version = '5.0'
   s.source_files = 'MapCache/Classes/**/*'
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.10'
   # s.resource_bundles = {
   #   'MapCache' => ['MapCache/Assets/*.png']

--- a/MapCache/Classes/MKMapView+MapCache.swift
+++ b/MapCache/Classes/MKMapView+MapCache.swift
@@ -39,7 +39,12 @@ extension MKMapView {
         }
         
         tileServerOverlay.tileSize = cache.config.tileSize
-        self.insertOverlay(tileServerOverlay, at: 0, level: .aboveLabels)
+        if let firstOverlay = self.overlays.first {
+            self.insertOverlay(tileServerOverlay, below: firstOverlay)
+        }
+        else {
+            self.addOverlay(tileServerOverlay, level: .aboveLabels)
+        }
         return tileServerOverlay
     }
 


### PR DESCRIPTION
iOS 16's `MKMapView`
```Swift
insertOverlay(tileServerOverlay, at: 0, level: .aboveLabels)
```

appears to be broken. Often, the overlay will overlap above other overlays even when insert at index 0. 
Refer to merlos/iOS-Open-GPX-Tracker#232 and https://github.com/merlos/iOS-Open-GPX-Tracker/commit/ec4edbdb6f46f4d26024273b02e1a849ddffc0d9#comments for more info.