### PR TITLE
Making canReplaceMapContent settable from outside

### DIFF
--- a/MapCache/Classes/MKMapView+MapCache.swift
+++ b/MapCache/Classes/MKMapView+MapCache.swift
@@ -16,6 +16,7 @@ extension MKMapView {
     /// Will tell the map to use the cache passed as parameter for getting the tiles.
     ///
     /// - Parameter cache: A cache that implements the `MapCacheProtocol`. Typically an instance of `MapCache`
+    /// - Parameter canReplaceMapContent: Does the overlay replace the default map? It can be used to add a tile layer with centain level of transparency.
     ///
     /// - SeeAlso: `Readme`
     @discardableResult

--- a/MapCache/Classes/MKMapView+MapCache.swift
+++ b/MapCache/Classes/MKMapView+MapCache.swift
@@ -19,10 +19,10 @@ extension MKMapView {
     ///
     /// - SeeAlso: `Readme`
     @discardableResult
-    public func useCache(_ cache: MapCacheProtocol) -> CachedTileOverlay {
+    public func useCache(_ cache: MapCacheProtocol, canReplaceMapContent: Bool = true) -> CachedTileOverlay {
 
         let tileServerOverlay = CachedTileOverlay(withCache: cache)
-        tileServerOverlay.canReplaceMapContent = true
+        tileServerOverlay.canReplaceMapContent = canReplaceMapContent
 
         // Don't set `maximumZ` when wanting "over zooming".
         // TileOverlay will stop trying in zoom levels beyond `maximumZ`.


### PR DESCRIPTION
It's a nice option to show OSM with alpha value over the Apple Maps satellite image