### PR TITLE
Feature: Add eTag support for efficient download

### DIFF
--- a/Example/MapCache/ViewController.swift
+++ b/Example/MapCache/ViewController.swift
@@ -36,6 +36,16 @@ class ViewController: UIViewController {
         // func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer
         map.delegate = self
         
+        // Default strategy is .cacheThenServer which looks into the cache and if not available
+        // makes a request the server. This is more efficient, however, the cache may be outdated (if the cached tiles
+        // were updated in the server)
+        
+        // .serverThenCache always queries the server to check if the tile in the cache is the latest (using eTags)
+        // if the version is the same, then it is not downloaded, if it is different, it gets the latest version.
+        //
+        //
+        config.loadTileMode = .serverThenCache
+        
         // initialize the cache with our config
         mapCache = MapCache(withConfig: config)
         // See documentation to know more about config options

--- a/Example/Tests/MapCacheTests.swift
+++ b/Example/Tests/MapCacheTests.swift
@@ -19,15 +19,31 @@ class MapCacheTests: QuickSpec {
     
     override func spec() {
         beforeSuite {
-            // This stub returns as data the URL of the request
             stub(condition: isHost("localhost")) { request in
                 let stubData = request.url?.description.data(using: String.Encoding.utf8)
               return HTTPStubsResponse(data: stubData!, statusCode:200, headers:nil)
             }
-            // This stub returns a 404 error
             stub(condition: isHost("brokenhost")) { request in
                 let stubData = request.url?.description.data(using: String.Encoding.utf8)
               return HTTPStubsResponse(data: stubData!, statusCode:404, headers:nil)
+            }
+            stub(condition: isHost("etaghost-store")) { request in
+                let stubData = "tile-data".data(using: .utf8)
+                return HTTPStubsResponse(data: stubData!, statusCode: 200, headers: ["ETag": "abc123"])
+            }
+            stub(condition: isHost("etaghost-header")) { request in
+                let stubData = "data".data(using: .utf8)
+                return HTTPStubsResponse(data: stubData!, statusCode: 200, headers: nil)
+            }
+            stub(condition: isHost("etaghost-304")) { request in
+                return HTTPStubsResponse(data: Data(), statusCode: 304, headers: nil)
+            }
+            stub(condition: isHost("etaghost-orphan")) { request in
+                if request.value(forHTTPHeaderField: "If-None-Match") != nil {
+                    return HTTPStubsResponse(data: Data(), statusCode: 304, headers: nil)
+                }
+                let stubData = "fresh-data".data(using: .utf8)
+                return HTTPStubsResponse(data: stubData!, statusCode: 200, headers: ["ETag": "new-etag"])
             }
         }
         
@@ -60,7 +76,6 @@ class MapCacheTests: QuickSpec {
             }
             
             it("can return error on fetch") {
-                //Set a template url that returns error (in this case does not use https)
                 let urlTemplate2 = "http://brokenhost/notworking"
                 let config2 = MapCacheConfig(withUrlTemplate: urlTemplate2)
                 let cache2 = MapCache(withConfig: config2)
@@ -70,7 +85,145 @@ class MapCacheTests: QuickSpec {
                     failure: {error in expect(true) == true},
                     success: {data in expect(true) == false} )
             }
-              
+        }
+        
+        describe("ETag caching") {
+            func makeCache(host: String) -> (cache: MapCache, path: MKTileOverlayPath, key: String) {
+                let urlTemplate = "https://\(host)/{s}/{x}/{y}/{z}"
+                var config = MapCacheConfig(withUrlTemplate: urlTemplate)
+                config.subdomains = ["ok"]
+                let cache = MapCache(withConfig: config)
+                let path = MKTileOverlayPath(x: 1, y: 2, z: 3, contentScaleFactor: 1.0)
+                let key = cache.cacheKey(forPath: path)
+                return (cache, path, key)
+            }
+
+            let (cache, path, key) = makeCache(host: "etaghost-store")
+
+            it("has an etagCache") {
+                expect(cache.etagCache).toNot(beNil())
+                expect(cache.etagCache).to(beAKindOf(DiskCache.self))
+            }
+
+            it("saves ETag from 200 response") {
+                waitUntil { done in
+                    cache.fetchTileFromServer(
+                        at: path,
+                        failure: { error in
+                            expect(error).to(beNil())
+                            done()
+                        },
+                        success: { _ in
+                            var etagResult: String?
+                            cache.etagCache.fetchDataSync(forKey: key,
+                                failure: nil,
+                                success: { etagData in
+                                    etagResult = String(data: etagData, encoding: .utf8)
+                                })
+                            expect(etagResult) == "abc123"
+                            done()
+                        })
+                }
+            }
+
+            it("sends If-None-Match when ETag is cached") {
+                let (headerCache, headerPath, headerKey) = makeCache(host: "etaghost-header")
+                let expectedEtag = "xyz"
+
+                var capturedIfNoneMatch: String?
+                stub(condition: isHost("etaghost-header")) { request in
+                    capturedIfNoneMatch = request.value(forHTTPHeaderField: "If-None-Match")
+                    let stubData = "data".data(using: .utf8)
+                    return HTTPStubsResponse(data: stubData!, statusCode: 200, headers: nil)
+                }
+
+                headerCache.etagCache.setDataSync(expectedEtag.data(using: .utf8)!, forKey: headerKey)
+
+                waitUntil { done in
+                    headerCache.fetchTileFromServer(
+                        at: headerPath,
+                        failure: { _ in
+                            expect(capturedIfNoneMatch) == expectedEtag
+                            done()
+                        },
+                        success: { _ in
+                            expect(capturedIfNoneMatch) == expectedEtag
+                            done()
+                        })
+                }
+            }
+
+            it("returns cached data on 304") {
+                let (localCache, localPath, localKey) = makeCache(host: "etaghost-304")
+
+                let cachedTileData = "cached-tile-content".data(using: .utf8)!
+                localCache.diskCache.setDataSync(cachedTileData, forKey: localKey)
+                localCache.etagCache.setDataSync("etag-304".data(using: .utf8)!, forKey: localKey)
+
+                waitUntil { done in
+                    localCache.fetchTileFromServer(
+                        at: localPath,
+                        failure: { _ in
+                            expect(false).to(beTrue())
+                            done()
+                        },
+                        success: { data in
+                            expect(data) == cachedTileData
+                            done()
+                        })
+                }
+            }
+
+            it("re-fetches on 304 when cached data is missing") {
+                let (localCache, localPath, localKey) = makeCache(host: "etaghost-orphan")
+
+                localCache.etagCache.setDataSync("orphan-etag".data(using: .utf8)!, forKey: localKey)
+
+                waitUntil { done in
+                    localCache.fetchTileFromServer(
+                        at: localPath,
+                        failure: { _ in
+                            expect(false).to(beTrue())
+                            done()
+                        },
+                        success: { data in
+                            expect(String(data: data, encoding: .utf8)) == "fresh-data"
+                            var newEtag: String?
+                            localCache.etagCache.fetchDataSync(forKey: localKey,
+                                failure: nil,
+                                success: { etagData in
+                                    newEtag = String(data: etagData, encoding: .utf8)
+                                })
+                            expect(newEtag) == "new-etag"
+                            done()
+                        })
+                }
+            }
+
+            it("clear removes both caches") {
+                let (localCache, localPath, localKey) = makeCache(host: "localhost")
+
+                localCache.diskCache.setDataSync("some-data".data(using: .utf8)!, forKey: localKey)
+                localCache.etagCache.setDataSync("some-etag".data(using: .utf8)!, forKey: localKey)
+
+                waitUntil { done in
+                    localCache.clear {
+                        var diskData: Data?
+                        localCache.diskCache.fetchDataSync(forKey: localKey,
+                            failure: nil,
+                            success: { data in diskData = data })
+                        expect(diskData).to(beNil())
+
+                        var etagData: Data?
+                        localCache.etagCache.fetchDataSync(forKey: localKey,
+                            failure: nil,
+                            success: { data in etagData = data })
+                        expect(etagData).to(beNil())
+
+                        done()
+                    }
+                }
+            }
         }
     }
 }

--- a/MapCache/Classes/LoadTileMode.swift
+++ b/MapCache/Classes/LoadTileMode.swift
@@ -17,17 +17,20 @@ public enum LoadTileMode {
     /// Default. If the tile exists in the cache, return it, otherwise, fetch it from server (and cache the result).
     case cacheThenServer
     
-    /// Always return the tile from the server unless there is some problem with the network.
-    /// Cache is updated everytime the tile is received.
-    /// Basically uses the cache as internet connection fallback
+    /// Always get the latest version from the server.
+    /// If the tile is cached it will check if it is the latest version (eTag). If the cached tile is not the last one, it will ask for it to the server (updating the cache)
+    /// If there is any issue getting the tile from the server (f.i. network is down), it uses the cached version.
+    ///
     case serverThenCache
           
     /// Only return data from cache.
     /// Useful for fully offline preloaded maps.
+    /// If the tile does not exist returns error.
     case cacheOnly
     
     /// Always return the tile from the server, as well as updating the cache.
     /// This mode may be useful for donwloading a whole map region.
     /// If a tile was not downloaded fron the server error is returned.
+    /// Always downloads and save to cache (does not use eTags)
     case serverOnly
    }

--- a/MapCache/Classes/MapCache.swift
+++ b/MapCache/Classes/MapCache.swift
@@ -89,6 +89,7 @@ open class MapCache : MapCacheProtocol {
     /// - Parameter success: if the image is downloaded
     
     public func fetchTileFromServer(at path: MKTileOverlayPath,
+                             skipEtag: Bool = false,
                              failure fail: ((Error?) -> ())? = nil,
                              success succeed: @escaping (Data) -> ()) {
         let url = self.url(forTilePath: path)
@@ -98,13 +99,15 @@ open class MapCache : MapCacheProtocol {
         var request = URLRequest(url: url)
         
         // Add If-None-Match header if we have a cached ETag
-        etagCache.fetchDataSync(forKey: key,
-            failure: nil,
-            success: { etagData in
-                if let etag = String(data: etagData, encoding: .utf8), !etag.isEmpty {
-                    request.setValue(etag, forHTTPHeaderField: "If-None-Match")
-                }
-            })
+        if !skipEtag {
+            etagCache.fetchDataSync(forKey: key,
+                failure: nil,
+                success: { etagData in
+                    if let etag = String(data: etagData, encoding: .utf8), !etag.isEmpty {
+                        request.setValue(etag, forHTTPHeaderField: "If-None-Match")
+                    }
+                })
+        }
         
         let task = URLSession.shared.dataTask(with: request) {(data, response, error) in
             if error != nil {
@@ -135,18 +138,22 @@ open class MapCache : MapCacheProtocol {
                     return
                 }
                 // Cached data was evicted but ETag survived — orphaned ETag
-                // Remove it and fail so the caller can retry fresh
+                // Remove it and re-fetch without conditional headers
                 self.etagCache.removeData(withKey: key)
-                print("MapCache::fetchTileFromServer 304 but data evicted, removing orphaned ETag url= \(url)")
+                print("MapCache::fetchTileFromServer 304 but data evicted, re-fetching url= \(url)")
+                self.fetchTileFromServer(at: path, skipEtag: true,
+                    failure: { error in fail!(error) },
+                    success: { data in succeed(data) })
+                return
             }
-            
+            // Handle 2xx success
             guard (200...299).contains(httpResponse.statusCode) else {
                 print("!!! MapCache::fetchTileFromServer statusCode != 2xx url= \(url)")
                 fail!(nil)
                 return
             }
             
-            // Save ETag from response headers
+            // 1. Save ETag from response headers
             let etag = httpResponse.allHeaderFields.first {
                 ($0.key as? String)?.lowercased() == "etag"
             }?.value as? String
@@ -154,9 +161,9 @@ open class MapCache : MapCacheProtocol {
                 self.etagCache.setDataSync(etagData, forKey: key)
             }
             
-            // Cache the tile data
+            // 2. Cache the tile data & return success
             self.diskCache.setDataSync(data, forKey: key)
-            print("MapCache::fetchTileFromServer Data received saved cacheKey=\(key)")
+            print("MapCache::fetchTileFromServer tile received saved cacheKey=\(key)")
             
             succeed(data)
         }
@@ -179,7 +186,8 @@ open class MapCache : MapCacheProtocol {
        // If it fails returns error to the caller.
         let tileFromServerFallback = { () -> () in
             print ("MapCache::tileFromServerFallback:: key=\(key)" )
-            self.fetchTileFromServer(at: path,
+            // we skip the ETag check here because we already tried it in the first attempt and it failed, so we want to force a fresh fetch from the server.
+            self.fetchTileFromServer(at: path, skipEtag: true,
                                 failure: {error in result(nil, error)},
                                 success: {data in
                                                print ("MapCache::fetchTileFromServer:: Data received cacheKey=\(key)" )
@@ -204,7 +212,9 @@ open class MapCache : MapCacheProtocol {
             fetchTileFromServer(at: path, failure: {error in tileFromCacheFallback()},
                                 success: {data in result(data, nil) })
         case .serverOnly:
-            fetchTileFromServer(at: path, failure: {error in result(nil, error)},
+            fetchTileFromServer(at: path, 
+                                skipEtag: true, // we want a fresh fetch from the server, so we skip the ETag check
+                                failure: {error in result(nil, error)},
                                 success: {data in result(data, nil)})
         case .cacheOnly:
             diskCache.fetchDataSync(forKey: key,

--- a/MapCache/Classes/MapCache.swift
+++ b/MapCache/Classes/MapCache.swift
@@ -25,6 +25,11 @@ open class MapCache : MapCacheProtocol {
     public var diskCache : DiskCache
     
     ///
+    /// It manages the physical storage of the ETags associated with the tiles
+    ///
+    public var etagCache : DiskCache
+    
+    ///
     /// Manages the queue of network requests for retrieving the tiles
     ///
     let operationQueue = OperationQueue()
@@ -37,6 +42,7 @@ open class MapCache : MapCacheProtocol {
     public init(withConfig config: MapCacheConfig ) {
         self.config = config
         diskCache = DiskCache(withName: config.cacheName, capacity: config.capacity)
+        etagCache = DiskCache(withName: "\(config.cacheName)-etags", capacity: UINT64_MAX)
     }
     
     ///
@@ -86,8 +92,21 @@ open class MapCache : MapCacheProtocol {
                              failure fail: ((Error?) -> ())? = nil,
                              success succeed: @escaping (Data) -> ()) {
         let url = self.url(forTilePath: path)
+        let key = cacheKey(forPath: path)
         print ("MapCache::fetchTileFromServer() url=\(url)")
-        let task = URLSession.shared.dataTask(with: url) {(data, response, error) in
+        
+        var request = URLRequest(url: url)
+        
+        // Add If-None-Match header if we have a cached ETag
+        etagCache.fetchDataSync(forKey: key,
+            failure: nil,
+            success: { etagData in
+                if let etag = String(data: etagData, encoding: .utf8), !etag.isEmpty {
+                    request.setValue(etag, forHTTPHeaderField: "If-None-Match")
+                }
+            })
+        
+        let task = URLSession.shared.dataTask(with: request) {(data, response, error) in
             if error != nil {
                 print("!!! MapCache::fetchTileFromServer Error for url= \(url) \(error.debugDescription)")
                 fail!(error)
@@ -98,12 +117,46 @@ open class MapCache : MapCacheProtocol {
                 fail!(nil)
                 return
             }
-            guard let httpResponse = response as? HTTPURLResponse,
-            (200...299).contains(httpResponse.statusCode) else {
+            guard let httpResponse = response as? HTTPURLResponse else {
+                print("!!! MapCache::fetchTileFromServer Invalid response url= \(url)")
+                fail!(nil)
+                return
+            }
+            
+            // Handle 304 Not Modified — return cached data if available
+            if httpResponse.statusCode == 304 {
+                var cachedData: Data?
+                self.diskCache.fetchDataSync(forKey: key,
+                    failure: nil,
+                    success: { data in cachedData = data })
+                if let data = cachedData {
+                    print("MapCache::fetchTileFromServer 304 Not Modified url= \(url)")
+                    succeed(data)
+                    return
+                }
+                // Cached data was evicted but ETag survived — orphaned ETag
+                // Remove it and fail so the caller can retry fresh
+                self.etagCache.removeData(withKey: key)
+                print("MapCache::fetchTileFromServer 304 but data evicted, removing orphaned ETag url= \(url)")
+            }
+            
+            guard (200...299).contains(httpResponse.statusCode) else {
                 print("!!! MapCache::fetchTileFromServer statusCode != 2xx url= \(url)")
                 fail!(nil)
                 return
             }
+            
+            // Save ETag from response headers
+            let etag = httpResponse.allHeaderFields.first {
+                ($0.key as? String)?.lowercased() == "etag"
+            }?.value as? String
+            if let etag = etag, let etagData = etag.data(using: .utf8) {
+                self.etagCache.setDataSync(etagData, forKey: key)
+            }
+            
+            // Cache the tile data
+            self.diskCache.setDataSync(data, forKey: key)
+            print("MapCache::fetchTileFromServer Data received saved cacheKey=\(key)")
             
             succeed(data)
         }
@@ -129,8 +182,7 @@ open class MapCache : MapCacheProtocol {
             self.fetchTileFromServer(at: path,
                                 failure: {error in result(nil, error)},
                                 success: {data in
-                                    self.diskCache.setData(data, forKey: key)
-                                               print ("MapCache::fetchTileFromServer:: Data received saved cacheKey=\(key)" )
+                                               print ("MapCache::fetchTileFromServer:: Data received cacheKey=\(key)" )
                                     result(data, nil)})
         }
         
@@ -184,7 +236,9 @@ open class MapCache : MapCacheProtocol {
     /// - Parameter completition: code to run upon the cache is cleared.
     
     public func clear(completition: (() -> ())? ) {
-        diskCache.removeAllData(completition)
+        diskCache.removeAllData {
+            self.etagCache.removeAllData(completition)
+        }
     }
     
 }


### PR DESCRIPTION
It implements eTag support. 
When a tile is downloaded, its eTag is also saved (in a DiskCache). 
Before downloading a tile, if the eTag is available it is included in the request. If the server resturns 304 (not modified) then the local version is up to date. Otherwise the server returns the whole tile.  
Whereas the implementation was built from scratch, the original idea is from  #41  

