### PR TITLE
Feature: Implement proper logging. Fix #9

### DIFF
--- a/Example/MapCache.xcodeproj/project.pbxproj
+++ b/Example/MapCache.xcodeproj/project.pbxproj
@@ -404,7 +404,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
@@ -457,7 +457,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
@@ -473,7 +473,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = MapCache/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -482,6 +482,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -490,7 +491,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = MapCache/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -499,6 +500,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -514,7 +516,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -523,6 +525,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MapCache_Example.app/MapCache_Example";
 			};
 			name = Debug;
@@ -535,7 +538,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -544,6 +547,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MapCache_Example.app/MapCache_Example";
 			};
 			name = Release;

--- a/MapCache/Classes/CachedTileOverlay.swift
+++ b/MapCache/Classes/CachedTileOverlay.swift
@@ -38,7 +38,7 @@ open class CachedTileOverlay : MKTileOverlay {
     /// - SeeAlso: `MapCache`, `MapCacheConfig`
     ///
     override public func url(forTilePath path: MKTileOverlayPath) -> URL {
-        //Log.cache.debug("url() urlTemplate: \(urlTemplate)")
+        //Log.cache.debug("urlTemplate: \(urlTemplate)")
         return mapCache.url(forTilePath: path)
     }
     

--- a/MapCache/Classes/CachedTileOverlay.swift
+++ b/MapCache/Classes/CachedTileOverlay.swift
@@ -38,7 +38,7 @@ open class CachedTileOverlay : MKTileOverlay {
     /// - SeeAlso: `MapCache`, `MapCacheConfig`
     ///
     override public func url(forTilePath path: MKTileOverlayPath) -> URL {
-        //print("CachedTileOverlay:: url() urlTemplate: \(urlTemplate)")
+        //Log.cache.debug("url() urlTemplate: \(urlTemplate)")
         return mapCache.url(forTilePath: path)
     }
     
@@ -49,7 +49,7 @@ open class CachedTileOverlay : MKTileOverlay {
     override open func loadTile(at path: MKTileOverlayPath,
                                   result: @escaping (Data?, Error?) -> Void) {
         if !self.useCache { // Use cache by use cache is not set.
-            // print("loadTile:: not using cache")
+            //Log.cache.debug("loadTile not using cache")
             return super.loadTile(at: path, result: result)
         } else {
             return mapCache.loadTile(at: path, result: result)

--- a/MapCache/Classes/DiskCache/DiskCache.swift
+++ b/MapCache/Classes/DiskCache/DiskCache.swift
@@ -80,7 +80,7 @@ open class DiskCache {
         do {
             try FileManager.default.createDirectory(at: self.folderURL, withIntermediateDirectories: true, attributes: nil)
         } catch {
-            Log.diskcache.error("init --- Failed to create directory \(self.folderURL.absoluteString) \(error)")
+            Log.diskcache.error("Failed to create directory \(self.folderURL.absoluteString) \(error)")
         }
         self.capacity = capacity
         cacheQueue.async(execute: {
@@ -107,7 +107,7 @@ open class DiskCache {
     /// Sets the data for the key synchronously.
     open func setDataSync(_ data: Data, forKey key: String) {
         let filePath = path(forKey: key)
-        Log.diskcache.debug("setDataSync --- filePath: \(filePath) data count: \(data.count) key: \(key) diskBlocks:\(Double(data.count) / 4096.0)")
+        Log.diskcache.debug("filePath: \(filePath) data count: \(data.count) key: \(key) diskBlocks:\(Double(data.count) / 4096.0)")
         //If the file exists get the current file diskSize.
         let fileURL = URL(fileURLWithPath: filePath)
         do {
@@ -117,7 +117,7 @@ open class DiskCache {
         do {
             try data.write(to: URL(fileURLWithPath: filePath), options: Data.WritingOptions.atomicWrite)
         } catch {
-            Log.diskcache.error("setDataSync --- Failed to write key: \(key) filepath: \(filePath) \(error)")
+            Log.diskcache.error("Failed to write key: \(key) filepath: \(filePath) \(error)")
         }
         //Now add to the diskSize the file size
         var diskBlocks = Double(data.count) / 4096.0
@@ -166,15 +166,15 @@ open class DiskCache {
                     let filePath = self.folderURL.appendingPathComponent(filename).path
                     do {
                         try fileManager.removeItem(atPath: filePath)
-                        Log.diskcache.debug("removeAllData --- Removed path \(filename)")
+                        Log.diskcache.debug("Removed path \(filename)")
                     } catch {
-                        Log.diskcache.error("removeAllData --- Failed to remove path \(filePath) \(error)")
+                        Log.diskcache.error("Failed to remove path \(filePath) \(error)")
                     }
                 }
                 self.diskSize = self.calculateDiskSize()
-                Log.diskcache.debug("removeAllData --- Size at the end \(self.diskSize)")
+                Log.diskcache.debug("Size at the end \(self.diskSize)")
             } catch {
-                Log.diskcache.error("removeAllData --- Failed to list directory \(error)")
+                Log.diskcache.error("Failed to list directory \(error)")
             }
             if let completion = completion {
                 DispatchQueue.main.async {
@@ -193,7 +193,7 @@ open class DiskCache {
         do {
             try FileManager.default.removeItem(at: self.folderURL)
         } catch {
-            Log.diskcache.error("removeCache --- Error removing DiskCache folder \(error)")
+            Log.diskcache.error("Error removing DiskCache folder \(error)")
         }
     }
     
@@ -206,7 +206,7 @@ open class DiskCache {
                 if let data = getData() {
                     self.setDataSync(data, forKey: key)
                 } else {
-                    Log.diskcache.error("updateAccessDate --- Failed to get data for key \(key)")
+                    Log.diskcache.error("Failed to get data for key \(key)")
                 }
             }
         })
@@ -220,7 +220,7 @@ open class DiskCache {
             currentSize = try fileManager.allocatedDiskSizeForDirectory(at: folderURL)
         }
         catch {
-            Log.diskcache.error("calculateDiskSize --- Failed to get diskSize of directory \(error)")
+            Log.diskcache.error("Failed to get diskSize of directory \(error)")
         }
         return currentSize
     }
@@ -249,7 +249,7 @@ open class DiskCache {
             try fileManager.setAttributes([FileAttributeKey.modificationDate : now], ofItemAtPath: path)
             return true
         } catch {
-            Log.diskcache.error("updateDiskAccessDate --- Failed to update access date \(error)")
+            Log.diskcache.error("Failed to update access date \(error)")
             return false
         }
     }
@@ -264,9 +264,9 @@ open class DiskCache {
             substract(diskSize: fileSize)
         } catch {
             if isNoSuchFileError(error) {
-                Log.diskcache.error("removeFile --- Failed to remove file. File not found \(error)")
+                Log.diskcache.error("Failed to remove file. File not found \(error)")
             } else {
-                Log.diskcache.error("removeFile --- Failed to remove file. Size or other error \(error)")
+                Log.diskcache.error("Failed to remove file. Size or other error \(error)")
             }
         }
     }
@@ -279,7 +279,7 @@ open class DiskCache {
         if (self.diskSize >= diskSize) {
             self.diskSize -= diskSize
         } else {
-            Log.diskcache.error("diskSize --- (\(self.diskSize)) is smaller than diskSize to substract (\(diskSize))")
+            Log.diskcache.error("diskSize (\(self.diskSize)) is smaller than diskSize to substract (\(diskSize))")
             self.diskSize = 0
         }
     }

--- a/MapCache/Classes/DiskCache/DiskCache.swift
+++ b/MapCache/Classes/DiskCache/DiskCache.swift
@@ -80,14 +80,14 @@ open class DiskCache {
         do {
             try FileManager.default.createDirectory(at: self.folderURL, withIntermediateDirectories: true, attributes: nil)
         } catch {
-            Log.error(message: "DiskCache::init --- Failed to create directory \(folderURL.absoluteString)", error: error)
+            Log.diskcache.error("init --- Failed to create directory \(self.folderURL.absoluteString) \(error)")
         }
         self.capacity = capacity
         cacheQueue.async(execute: {
             self.diskSize = self.calculateDiskSize()
             self.controlCapacity()
         })
-        //Log.debug(message: "DiskCache folderURL=\(folderURL.absoluteString)")
+        //Log.diskcache.debug("folderURL=\(folderURL.absoluteString)")
     }
     
     
@@ -107,7 +107,7 @@ open class DiskCache {
     /// Sets the data for the key synchronously.
     open func setDataSync(_ data: Data, forKey key: String) {
         let filePath = path(forKey: key)
-        Log.debug(message: "DiskCache::setDataSync --- filePath: \(filePath) data count: \(data.count) key: \(key) diskBlocks:\(Double(data.count) / 4096.0)")
+        Log.diskcache.debug("setDataSync --- filePath: \(filePath) data count: \(data.count) key: \(key) diskBlocks:\(Double(data.count) / 4096.0)")
         //If the file exists get the current file diskSize.
         let fileURL = URL(fileURLWithPath: filePath)
         do {
@@ -117,7 +117,7 @@ open class DiskCache {
         do {
             try data.write(to: URL(fileURLWithPath: filePath), options: Data.WritingOptions.atomicWrite)
         } catch {
-            Log.error(message: "DiskCache::setDataSync --- Failed to write key: \(key) filepath: \(filePath)", error: error)
+            Log.diskcache.error("setDataSync --- Failed to write key: \(key) filepath: \(filePath) \(error)")
         }
         //Now add to the diskSize the file size
         var diskBlocks = Double(data.count) / 4096.0
@@ -166,15 +166,15 @@ open class DiskCache {
                     let filePath = self.folderURL.appendingPathComponent(filename).path
                     do {
                         try fileManager.removeItem(atPath: filePath)
-                        Log.debug(message: "DiskCache::removeAllData --- Removed path \(filename)")
+                        Log.diskcache.debug("removeAllData --- Removed path \(filename)")
                     } catch {
-                        Log.error(message: "DiskCache::removeAllData --- Failed to remove path \(filePath)", error: error)
+                        Log.diskcache.error("removeAllData --- Failed to remove path \(filePath) \(error)")
                     }
                 }
                 self.diskSize = self.calculateDiskSize()
-                Log.debug(message: "DiskCache::removeAllData --- Size at the end \(self.diskSize)")
+                Log.diskcache.debug("removeAllData --- Size at the end \(self.diskSize)")
             } catch {
-                Log.error(message: "DiskCache::removeAllData --- Failed to list directory", error: error)
+                Log.diskcache.error("removeAllData --- Failed to list directory \(error)")
             }
             if let completion = completion {
                 DispatchQueue.main.async {
@@ -193,7 +193,7 @@ open class DiskCache {
         do {
             try FileManager.default.removeItem(at: self.folderURL)
         } catch {
-            Log.error(message: "Diskcache::removeCache --- Error removing DiskCache folder", error: error)
+            Log.diskcache.error("removeCache --- Error removing DiskCache folder \(error)")
         }
     }
     
@@ -206,7 +206,7 @@ open class DiskCache {
                 if let data = getData() {
                     self.setDataSync(data, forKey: key)
                 } else {
-                    Log.error(message: "DiskCache::updateAccessDate --- Failed to get data for key \(key)")
+                    Log.diskcache.error("updateAccessDate --- Failed to get data for key \(key)")
                 }
             }
         })
@@ -220,7 +220,7 @@ open class DiskCache {
             currentSize = try fileManager.allocatedDiskSizeForDirectory(at: folderURL)
         }
         catch {
-            Log.error(message: "DiskCache::calculateDiskSize --- Failed to get diskSize of directory", error: error)
+            Log.diskcache.error("calculateDiskSize --- Failed to get diskSize of directory \(error)")
         }
         return currentSize
     }
@@ -249,7 +249,7 @@ open class DiskCache {
             try fileManager.setAttributes([FileAttributeKey.modificationDate : now], ofItemAtPath: path)
             return true
         } catch {
-            Log.error(message: "DiskCache::updateDiskAccessDate --- Failed to update access date", error: error)
+            Log.diskcache.error("updateDiskAccessDate --- Failed to update access date \(error)")
             return false
         }
     }
@@ -264,9 +264,9 @@ open class DiskCache {
             substract(diskSize: fileSize)
         } catch {
             if isNoSuchFileError(error) {
-                Log.error(message: "DiskCache::removeFile --- Failed to remove file. File not found", error: error)
+                Log.diskcache.error("removeFile --- Failed to remove file. File not found \(error)")
             } else {
-                Log.error(message: "DiskCache::removeFile --- Failed to remove file. Size or other error", error: error)
+                Log.diskcache.error("removeFile --- Failed to remove file. Size or other error \(error)")
             }
         }
     }
@@ -279,7 +279,7 @@ open class DiskCache {
         if (self.diskSize >= diskSize) {
             self.diskSize -= diskSize
         } else {
-            Log.error(message: "DiskCache::diskSize --- (\(self.diskSize)) is smaller than diskSize to substract (\(diskSize))")
+            Log.diskcache.error("diskSize --- (\(self.diskSize)) is smaller than diskSize to substract (\(diskSize))")
             self.diskSize = 0
         }
     }

--- a/MapCache/Classes/DiskCache/FileManager+DiskCache.swift
+++ b/MapCache/Classes/DiskCache/FileManager+DiskCache.swift
@@ -69,7 +69,7 @@ extension FileManager {
             }
             
         } catch {
-            Log.error(message: "Failed to list directory", error: error)
+            Log.diskcache.error("Failed to list directory \(error)")
         }
     }
     

--- a/MapCache/Classes/Log.swift
+++ b/MapCache/Classes/Log.swift
@@ -11,6 +11,21 @@ import os
 ///
 /// Thin wrapper around os.Logger that automatically captures file, function and line numbers.
 ///
+/// Usage:
+/// ```
+///   Log.cache.debug("my debug message")
+///   // prints: MapCache.swift[42]::myMethod -- my debug message
+///
+///   Log.cache.error("tile not found with error \(error)")
+///   // prints: MapCache.swift[99]::fetchTile -- tile not found with error ...
+///
+///   Log.diskcache.info("cache size calculated")
+///   // prints: DiskCache.swift[55]::calculateDiskSize -- cache size calculated
+///
+///   Log.downloader.trace("network request started")
+///   // prints: RegionDownloader.swift[77]::start -- network request started
+/// ```
+///
 struct Log {
     let logger: Logger
 
@@ -25,33 +40,48 @@ struct Log {
         return function
     }
 
+    /// Log at `.debug` level. Extremely verbose, not persisted, development only.
     func trace(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         logger.log(level: .debug, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
+    /// Log at `.debug` level. Not persisted, useful during development.
     func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         logger.log(level: .debug, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
+    /// Log at `.info` level. Persisted in the log archive, useful for important state changes.
     func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         logger.log(level: .info, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
+    /// Log at `.default` level. Noteworthy events that are not errors.
     func notice(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         logger.log(level: .default, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
+    /// Log at `.error` level. Recoverable errors that should be investigated.
     func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         logger.log(level: .error, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
+    /// Log at `.fault` level. Critical failures that may impact app stability.
     func fault(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         logger.log(level: .fault, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 }
 
+///
+/// Pre-configured loggers for each MapCache subsystem category.
+///
 extension Log {
+
+    /// Cache operations (tile fetching, URL building, ETag handling)
     static let cache = Log(subsystem: "org.merlos.mapcache", category: "cache")
+
+    /// Disk storage operations (read/write/eviction)
     static let diskcache = Log(subsystem: "org.merlos.mapcache", category: "diskcache")
+
+    /// Region downloader operations
     static let downloader = Log(subsystem: "org.merlos.mapcache", category: "downloader")
 }

--- a/MapCache/Classes/Log.swift
+++ b/MapCache/Classes/Log.swift
@@ -26,27 +26,27 @@ struct Log {
     }
 
     func trace(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        logger.log(level: .debug, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
+        logger.log(level: .debug, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
     func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        logger.log(level: .debug, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
+        logger.log(level: .debug, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
     func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        logger.log(level: .info, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
+        logger.log(level: .info, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
     func notice(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        logger.log(level: .default, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
+        logger.log(level: .default, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
     func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        logger.log(level: .error, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
+        logger.log(level: .error, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 
     func fault(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        logger.log(level: .fault, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
+        logger.log(level: .fault, "\((file as NSString).lastPathComponent)[\(line)]::\(Self.baseName(function)) -- \(message)")
     }
 }
 

--- a/MapCache/Classes/Log.swift
+++ b/MapCache/Classes/Log.swift
@@ -5,12 +5,11 @@
 //  Created by merlos on 02/06/2019.
 //
 
-
 import Foundation
 import os
 
 ///
-/// Thin wrapper around os.Logger that automatically captures file and line numbers.
+/// Thin wrapper around os.Logger that automatically captures file, function and line numbers.
 ///
 struct Log {
     let logger: Logger
@@ -19,28 +18,35 @@ struct Log {
         logger = Logger(subsystem: subsystem, category: category)
     }
 
-    func trace(_ message: String, file: String = #file, line: Int = #line) {
-        logger.log(level: .debug, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    private static func baseName(_ function: String) -> String {
+        if let parenIndex = function.firstIndex(of: "(") {
+            return String(function[..<parenIndex])
+        }
+        return function
     }
 
-    func debug(_ message: String, file: String = #file, line: Int = #line) {
-        logger.log(level: .debug, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    func trace(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.log(level: .debug, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
     }
 
-    func info(_ message: String, file: String = #file, line: Int = #line) {
-        logger.log(level: .info, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.log(level: .debug, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
     }
 
-    func notice(_ message: String, file: String = #file, line: Int = #line) {
-        logger.log(level: .default, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.log(level: .info, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
     }
 
-    func error(_ message: String, file: String = #file, line: Int = #line) {
-        logger.log(level: .error, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    func notice(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.log(level: .default, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
     }
 
-    func fault(_ message: String, file: String = #file, line: Int = #line) {
-        logger.log(level: .fault, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.log(level: .error, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
+    }
+
+    func fault(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.log(level: .fault, "\((file as NSString).lastPathComponent):\(line) \(Self.baseName(function)) \(message)")
     }
 }
 

--- a/MapCache/Classes/Log.swift
+++ b/MapCache/Classes/Log.swift
@@ -4,81 +4,48 @@
 //
 //  Created by merlos on 02/06/2019.
 //
-// Based on Haneke' Log File
-// https://github.com/Haneke/HanekeSwift/blob/master/Haneke/Log.swift
-//
 
 
 import Foundation
+import os
 
 ///
-/// For logging messages on console.
+/// Thin wrapper around os.Logger that automatically captures file and line numbers.
 ///
-/// The log format is `<tag><Level> <message> [with error <error>]`:
-/// Examples:
-/// ```
-///   [MapCache][DEBUG] Welcome to MapCache
-///   [MapCache][ERROR] Could not download file with error Unknown address
-///
-/// ```
-///
-///
-public struct Log {
-    
-    /// The tag [MapCache]
-    fileprivate static let tag = "[MapCache]"
-    
-    /// Log Levels
-    fileprivate enum Level : String {
-        /// `[Debug]` For displaying messages useful during development.
-        case Debug = "[DEBUG]"
-        /// `[ERROR]`For displaying messages of bad situations, very, very bad situations.
-        case Error = "[ERROR]"
-    }
-    
-    ///
-    /// The actual method that prints.
-    /// - Parameter level: log level to show
-    /// - Parameter message: message to show
-    /// - Parameter error: error to show if any on addition to the message. Uses the pattern `{message} with error {error}`
-    fileprivate static func log(_ level: Level, _ message: @autoclosure () -> String, _ error: Error? = nil) {
-        if let error = error {
-            print("\(tag)\(level.rawValue) \(message()) with error \(error)")
-        } else {
-            print("\(tag)\(level.rawValue) \(message())")
-        }
-    }
-    
-    ///
-    /// For displaying messages. Useful during development of this package.
-    ///
-    /// Example:
-    /// ```
-    /// Log.debug("Hello world") // prints: [MapCache][DEBUG] Hello word
-    /// ```
-    ///
-    /// These messages are displayed only if DEBUG is defined.
-    /// - Parameter message: message to display
-    /// - Parameter error: error to display if any.
-    static func debug(message: @autoclosure () -> String, error: Error? = nil) {
-        #if DEBUG
-        log(.Debug, message(), error)
-        #endif
-    }
-    
-    ///
-    /// These messages are displayed independently of the debug mode.
-    /// Used  to provide useful information on exceptional situations to library users.
-    /// Example:
-    /// ```
-    /// Log.error("Could not download tile", error) // prints: [MapCache][ERROR] Could not download tile with error No internet connection.
-    /// ```
-    ///
-    /// - Parameter message: message to display
-    /// - Parameter error: error to display
+struct Log {
+    let logger: Logger
 
-    static func error(message: @autoclosure () -> String, error: Error? = nil) {
-        log(.Error, message(), error)
+    init(subsystem: String, category: String) {
+        logger = Logger(subsystem: subsystem, category: category)
     }
-    
+
+    func trace(_ message: String, file: String = #file, line: Int = #line) {
+        logger.log(level: .debug, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    }
+
+    func debug(_ message: String, file: String = #file, line: Int = #line) {
+        logger.log(level: .debug, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    }
+
+    func info(_ message: String, file: String = #file, line: Int = #line) {
+        logger.log(level: .info, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    }
+
+    func notice(_ message: String, file: String = #file, line: Int = #line) {
+        logger.log(level: .default, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    }
+
+    func error(_ message: String, file: String = #file, line: Int = #line) {
+        logger.log(level: .error, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    }
+
+    func fault(_ message: String, file: String = #file, line: Int = #line) {
+        logger.log(level: .fault, "\((file as NSString).lastPathComponent):\(line) \(message)")
+    }
+}
+
+extension Log {
+    static let cache = Log(subsystem: "org.merlos.mapcache", category: "cache")
+    static let diskcache = Log(subsystem: "org.merlos.mapcache", category: "diskcache")
+    static let downloader = Log(subsystem: "org.merlos.mapcache", category: "downloader")
 }

--- a/MapCache/Classes/MapCache.swift
+++ b/MapCache/Classes/MapCache.swift
@@ -57,12 +57,12 @@ open class MapCache : MapCacheProtocol {
     /// - SeeAlso: MapCacheConfig.roundRoubinSubdomain()
     
     public func url(forTilePath path: MKTileOverlayPath) -> URL {
-        //print("CachedTileOverlay:: url() urlTemplate: \(urlTemplate)")
+        //Log.cache.debug("url() urlTemplate: \(urlTemplate)")
         var urlString = config.urlTemplate.replacingOccurrences(of: "{z}", with: String(path.z))
         urlString = urlString.replacingOccurrences(of: "{x}", with: String(path.x))
         urlString = urlString.replacingOccurrences(of: "{y}", with: String(path.y))
         urlString = urlString.replacingOccurrences(of: "{s}", with: config.roundRobinSubdomain() ?? "")
-        Log.debug(message: "MapCache::url() urlString: \(urlString)")
+        Log.cache.debug("url() urlString: \(urlString)")
         return URL(string: urlString)!
     }
     
@@ -94,7 +94,7 @@ open class MapCache : MapCacheProtocol {
                              success succeed: @escaping (Data) -> ()) {
         let url = self.url(forTilePath: path)
         let key = cacheKey(forPath: path)
-        print ("MapCache::fetchTileFromServer() url=\(url)")
+        Log.cache.debug("fetchTileFromServer() url=\(url)")
         
         var request = URLRequest(url: url)
         
@@ -111,17 +111,17 @@ open class MapCache : MapCacheProtocol {
         
         let task = URLSession.shared.dataTask(with: request) {(data, response, error) in
             if error != nil {
-                print("!!! MapCache::fetchTileFromServer Error for url= \(url) \(error.debugDescription)")
+                Log.cache.error("fetchTileFromServer Error for url= \(url) \(error.debugDescription)")
                 fail!(error)
                 return
             }
             guard let data = data else {
-                print("!!! MapCache::fetchTileFromServer No data for url= \(url)")
+                Log.cache.error("fetchTileFromServer No data for url= \(url)")
                 fail!(nil)
                 return
             }
             guard let httpResponse = response as? HTTPURLResponse else {
-                print("!!! MapCache::fetchTileFromServer Invalid response url= \(url)")
+                Log.cache.error("fetchTileFromServer Invalid response url= \(url)")
                 fail!(nil)
                 return
             }
@@ -133,14 +133,14 @@ open class MapCache : MapCacheProtocol {
                     failure: nil,
                     success: { data in cachedData = data })
                 if let data = cachedData {
-                    print("MapCache::fetchTileFromServer 304 Not Modified url= \(url)")
+                    Log.cache.info("fetchTileFromServer 304 Not Modified url= \(url)")
                     succeed(data)
                     return
                 }
                 // Cached data was evicted but ETag survived — orphaned ETag
                 // Remove it and re-fetch without conditional headers
                 self.etagCache.removeData(withKey: key)
-                print("MapCache::fetchTileFromServer 304 but data evicted, re-fetching url= \(url)")
+                Log.cache.notice("fetchTileFromServer 304 but data evicted, re-fetching url= \(url)")
                 self.fetchTileFromServer(at: path, skipEtag: true,
                     failure: { error in fail!(error) },
                     success: { data in succeed(data) })
@@ -148,7 +148,7 @@ open class MapCache : MapCacheProtocol {
             }
             // Handle 2xx success
             guard (200...299).contains(httpResponse.statusCode) else {
-                print("!!! MapCache::fetchTileFromServer statusCode != 2xx url= \(url)")
+                Log.cache.error("fetchTileFromServer statusCode != 2xx url= \(url)")
                 fail!(nil)
                 return
             }
@@ -163,7 +163,7 @@ open class MapCache : MapCacheProtocol {
             
             // 2. Cache the tile data & return success
             self.diskCache.setDataSync(data, forKey: key)
-            print("MapCache::fetchTileFromServer tile received saved cacheKey=\(key)")
+            Log.cache.info("fetchTileFromServer tile received saved cacheKey=\(key)")
             
             succeed(data)
         }
@@ -185,12 +185,12 @@ open class MapCache : MapCacheProtocol {
        // Tries to load the tile from the server.
        // If it fails returns error to the caller.
         let tileFromServerFallback = { () -> () in
-            print ("MapCache::tileFromServerFallback:: key=\(key)" )
+            Log.cache.debug("tileFromServerFallback:: key=\(key)")
             // we skip the ETag check here because we already tried it in the first attempt and it failed, so we want to force a fresh fetch from the server.
             self.fetchTileFromServer(at: path, skipEtag: true,
                                 failure: {error in result(nil, error)},
                                 success: {data in
-                                               print ("MapCache::fetchTileFromServer:: Data received cacheKey=\(key)" )
+                                               Log.cache.debug("fetchTileFromServer:: Data received cacheKey=\(key)")
                                     result(data, nil)})
         }
         

--- a/MapCache/Classes/MapCache.swift
+++ b/MapCache/Classes/MapCache.swift
@@ -57,12 +57,12 @@ open class MapCache : MapCacheProtocol {
     /// - SeeAlso: MapCacheConfig.roundRoubinSubdomain()
     
     public func url(forTilePath path: MKTileOverlayPath) -> URL {
-        //Log.cache.debug("url() urlTemplate: \(urlTemplate)")
+        //Log.cache.debug("urlTemplate: \(urlTemplate)")
         var urlString = config.urlTemplate.replacingOccurrences(of: "{z}", with: String(path.z))
         urlString = urlString.replacingOccurrences(of: "{x}", with: String(path.x))
         urlString = urlString.replacingOccurrences(of: "{y}", with: String(path.y))
         urlString = urlString.replacingOccurrences(of: "{s}", with: config.roundRobinSubdomain() ?? "")
-        Log.cache.debug("url() urlString: \(urlString)")
+        Log.cache.debug("urlString: \(urlString)")
         return URL(string: urlString)!
     }
     
@@ -94,7 +94,7 @@ open class MapCache : MapCacheProtocol {
                              success succeed: @escaping (Data) -> ()) {
         let url = self.url(forTilePath: path)
         let key = cacheKey(forPath: path)
-        Log.cache.debug("fetchTileFromServer() url=\(url)")
+        Log.cache.debug("url=\(url)")
         
         var request = URLRequest(url: url)
         
@@ -111,17 +111,17 @@ open class MapCache : MapCacheProtocol {
         
         let task = URLSession.shared.dataTask(with: request) {(data, response, error) in
             if error != nil {
-                Log.cache.error("fetchTileFromServer Error for url= \(url) \(error.debugDescription)")
+                Log.cache.error("Error for url= \(url) \(error.debugDescription)")
                 fail!(error)
                 return
             }
             guard let data = data else {
-                Log.cache.error("fetchTileFromServer No data for url= \(url)")
+                Log.cache.error("No data for url= \(url)")
                 fail!(nil)
                 return
             }
             guard let httpResponse = response as? HTTPURLResponse else {
-                Log.cache.error("fetchTileFromServer Invalid response url= \(url)")
+                Log.cache.error("Invalid response url= \(url)")
                 fail!(nil)
                 return
             }
@@ -133,14 +133,14 @@ open class MapCache : MapCacheProtocol {
                     failure: nil,
                     success: { data in cachedData = data })
                 if let data = cachedData {
-                    Log.cache.info("fetchTileFromServer 304 Not Modified url= \(url)")
+                    Log.cache.info("304 Not Modified url= \(url)")
                     succeed(data)
                     return
                 }
                 // Cached data was evicted but ETag survived — orphaned ETag
                 // Remove it and re-fetch without conditional headers
                 self.etagCache.removeData(withKey: key)
-                Log.cache.notice("fetchTileFromServer 304 but data evicted, re-fetching url= \(url)")
+                Log.cache.notice("304 but data evicted, re-fetching url= \(url)")
                 self.fetchTileFromServer(at: path, skipEtag: true,
                     failure: { error in fail!(error) },
                     success: { data in succeed(data) })
@@ -148,7 +148,7 @@ open class MapCache : MapCacheProtocol {
             }
             // Handle 2xx success
             guard (200...299).contains(httpResponse.statusCode) else {
-                Log.cache.error("fetchTileFromServer statusCode != 2xx url= \(url)")
+                Log.cache.error("statusCode != 2xx url= \(url)")
                 fail!(nil)
                 return
             }
@@ -163,7 +163,7 @@ open class MapCache : MapCacheProtocol {
             
             // 2. Cache the tile data & return success
             self.diskCache.setDataSync(data, forKey: key)
-            Log.cache.info("fetchTileFromServer tile received saved cacheKey=\(key)")
+            Log.cache.info("tile received saved cacheKey=\(key)")
             
             succeed(data)
         }
@@ -185,12 +185,12 @@ open class MapCache : MapCacheProtocol {
        // Tries to load the tile from the server.
        // If it fails returns error to the caller.
         let tileFromServerFallback = { () -> () in
-            Log.cache.debug("tileFromServerFallback:: key=\(key)")
+            Log.cache.debug("tileFromServerFallback key=\(key)")
             // we skip the ETag check here because we already tried it in the first attempt and it failed, so we want to force a fresh fetch from the server.
             self.fetchTileFromServer(at: path, skipEtag: true,
                                 failure: {error in result(nil, error)},
                                 success: {data in
-                                               Log.cache.debug("fetchTileFromServer:: Data received cacheKey=\(key)")
+                                               Log.cache.debug("Data received cacheKey=\(key)")
                                     result(data, nil)})
         }
         

--- a/MapCache/Classes/RegionDownloader.swift
+++ b/MapCache/Classes/RegionDownloader.swift
@@ -193,14 +193,14 @@ import MapKit
                     self.mapCache.loadTile(at: mktileOverlayPath, result: { data, error in
                         semaphore.signal()
                         if error != nil {
-                            print(error?.localizedDescription ?? "Error downloading tile")
+                            Log.downloader.error("\(error?.localizedDescription ?? "Error downloading tile")")
                             self._failedTileDownloads += 1
                             // TODO add to an array of tiles not downloaded
                             // so a retry can be performed
                         } else {
                             self._successfulTileDownloads += 1
                             self._downloadedBytes += UInt64(data?.count ?? 0)
-                            print("RegionDownloader:: Donwloaded zoom: \(tileCoords.zoom) (x:\(tileCoords.tileX),y:\(tileCoords.tileY), data.count: \(data?.count ?? 0)) \(self.downloadedTiles)/\(self.totalTilesToDownload) \(self.downloadedPercentage)%, bytes: \(self.downloadedBytes), average tile size: \(self.averageTileSizeBytes)")
+                            Log.downloader.debug("Donwloaded zoom: \(tileCoords.zoom) (x:\(tileCoords.tileX),y:\(tileCoords.tileY), data.count: \(data?.count ?? 0)) \(self.downloadedTiles)/\(self.totalTilesToDownload) \(self.downloadedPercentage)%, bytes: \(self.downloadedBytes), average tile size: \(self.averageTileSizeBytes)")
                             
                         }
                         //check if needs to notify duet to percentage
@@ -240,7 +240,7 @@ import MapKit
 public extension DispatchTime {
 
     init(after: TimeInterval) {
-        print("DispatchTime.after: \(after) seconds")
+        Log.downloader.trace("DispatchTime.after: \(after) seconds")
         self.init(uptimeNanoseconds:DispatchTime.now().uptimeNanoseconds + UInt64(after * 1_000_000_000))
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MapCache",
     platforms: [
-        .iOS(.v14), .macOS(.v10_13)
+        .iOS(.v14), .macOS(.v11)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MapCache",
     platforms: [
-        .iOS(.v11), .macOS(.v10_13)
+        .iOS(.v14), .macOS(.v10_13)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
Closes #9 

Logger: 

* It now uses Logger behind the scenes. This allows filtering in the log console of Xcode.
* Displays the file, line and function calling automatically (no longer needs to be added as part of the message itself)
* Bumped to ios14 to enable the use Logger.

Examples of usage.

```swift
 Log.cache.debug("my debug message")
 // prints: MapCache.swift[42]::myMethod -- my debug message
 
Log.cache.error("tile not found with error \(error)")
// prints: MapCache.swift[99]::fetchTile -- tile not found with error ...

  Log.diskcache.info("cache size calculated")
// prints: DiskCache.swift[55]::calculateDiskSize -- cache size calculated

Log.downloader.trace("network request started")
   // prints: RegionDownloader.swift[77]::start -- network request started
