### PR TITLE
Fix #46 Max zoom ignored when greater than 19

### DIFF
--- a/Example/Tests/TileCoordsSpecs.swift
+++ b/Example/Tests/TileCoordsSpecs.swift
@@ -47,13 +47,13 @@ class TileCoordsSpecs: QuickSpec {
                 // For the initializer with a tileCoord, the only way to get nil
                 // is to set an invalid zoom
                 let tileCoordsOk = TileCoords(latitude: lat, longitude: lon, zoom: zoom)!
-                let tileCoords4 = TileCoords(tileCoordsOk, zoom: 20)
+                let tileCoords4 = TileCoords(tileCoordsOk, zoom: 30)
                 expect(tileCoords4).to(beNil())
             }
             it ("can validate max and mins") {
                 //zoom
                 try! TileCoords.validate(zoom: 0)
-                expect { try TileCoords.validate(zoom: 20)}.to(throwError())
+                expect { try TileCoords.validate(zoom: 30)}.to(throwError())
                 //Tiles
                 try! TileCoords.validate(tile: 1, forZoom: 10)
                 expect { try TileCoords.validate(tile: 1024, forZoom: 10)}.to(throwError())

--- a/Example/Tests/TileRegionSpecs.swift
+++ b/Example/Tests/TileRegionSpecs.swift
@@ -132,7 +132,7 @@ class TileRegionSpecs: QuickSpec {
                                 zoom: TileCoords.minZoom)
                 let bR = TileCoords(latitude: TileCoords.minLatitude,
                                 longitude: TileCoords.maxLongitude,
-                                zoom: TileCoords.maxZoom)
+                                zoom: 19) // default max zoom level
                 let world = TileCoordsRegion(topLeft: tL!, bottomRight: bR!)!
                 // count = 1 + 4 + 16 + 64 + ... 4^zoom ... 4^19
                 expect(world.count).to(equal(366503875925))

--- a/Example/Tests/ZoomRangeSpecs.swift
+++ b/Example/Tests/ZoomRangeSpecs.swift
@@ -24,10 +24,10 @@ class ZoomRangeSpecs: QuickSpec {
             }
             
             it("does not init with invalid zooms") {
-                let z1 = ZoomRange(20,2)
+                let z1 = ZoomRange(30,2)
                 expect(z1).to(beNil())
                 
-                let z2 = ZoomRange(2,20)
+                let z2 = ZoomRange(2,30)
                 expect(z2).to(beNil())
             }
             

--- a/MapCache/Classes/MapCacheConfig.swift
+++ b/MapCache/Classes/MapCacheConfig.swift
@@ -43,9 +43,10 @@ public struct MapCacheConfig  {
     ///
     /// Tiles with a z zoom beyond `maximumZ` supported by the tile server will return a HTTP 404 error.
     ///
-    /// Values vary from server to server. For example OpenStreetMap supports 19, but  OpenCycleMap supports 22
+    /// Values vary from server to server. For example OpenStreetMap supports 19, but OpenCycleMap supports 22.
+    /// The maximum value that can be set is `TileCoords.maxZoom` (25).
     ///
-    /// Default value: 19. If 0 or negative is set iOS default value (i.e. 21)
+    /// Default value: 19. If 0 or negative is set iOS default value (i.e. 21).
     ///
     /// - SeeAlso:  [OpenStreetMap Wiki Slippy map tilenames](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
     ///

--- a/MapCache/Classes/TileCoords.swift
+++ b/MapCache/Classes/TileCoords.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// An alias for UInt8. Used to indicate that the variable is holding a zoom value.
 ///
-/// Notice that Zoom shoul have only values between 0 and 19.
+/// Notice that Zoom shoul have only values between 0 and 25.
 /// - SeeAlso: TileCoords
 public typealias Zoom = UInt8
 
@@ -19,8 +19,8 @@ public typealias TileNumber = UInt64
 
 /// Errors for Zoom.
 public enum ZoomError: Error {
-    /// Zoom largest value is 19.
-    case largerThan19
+    /// Zoom value exceeds the maximum allowed.
+    case exceedsMaximum
 }
 
 /// Errors for a latitude.
@@ -52,7 +52,7 @@ public enum TileError: Error {
 /// The max latitude that can be converted to tiles is +85.0511 and the minimum
 ///  is -85.0511 (see https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames).
 ///
-/// Zoom level (z) range is from 0 to 19.
+/// Zoom level (z) range is from 0 to 25.
 ///
 /// The earth is represented by a square that is divided in small pieces (tiles).
 /// The number of tiles depends on the zoom value and is equal to: 2^z x 2^z
@@ -93,8 +93,8 @@ open class TileCoords {
     static let minLongitude : Double = -180.0
     
     
-    /// Max zoom supported in tile servers (19)
-    static let maxZoom : Zoom = 19
+    /// Max zoom supported in tile servers (25)
+    static let maxZoom : Zoom = 25
     
     /// Min zoom supported (0)
     static let minZoom : Zoom = 0
@@ -131,7 +131,7 @@ open class TileCoords {
     /// Throws ZoomError if is greater than maxZoom
     static public func validate(zoom: Zoom) throws -> Void {
         if zoom > maxZoom {
-            throw ZoomError.largerThan19
+            throw ZoomError.exceedsMaximum
         }
     }
     


### PR DESCRIPTION
See #46 

Now it is allowed to have a Max zoom of up to 25 which his a practical limit which may not be reached.

* Standard Web Maps (OSM): Max native zoom is typically 19. 
* Commercial APIs (Mapbox/Google): Support up to 22. 
* High-Detail Services: Can reach 23 with appropriate source data (f.i. ArcGIS supports it)
