### PR TITLE
Feature: implement cache index for efficient evictions

### DIFF
--- a/Example/MapCache.xcodeproj/project.pbxproj
+++ b/Example/MapCache.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		895E71B322C2EA140006977C /* RegionDownloaderSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895E71B222C2EA140006977C /* RegionDownloaderSpecs.swift */; };
 		895E71B822CB13090006977C /* DownloaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895E71B722CB13090006977C /* DownloaderViewController.swift */; };
 		897DE7EE22976D7E0054A9A1 /* MapCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897DE7ED22976D7E0054A9A1 /* MapCacheTests.swift */; };
+		898B22162FFC4D750085039C /* CacheIndexSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898B22152FFC4D750085039C /* CacheIndexSpecs.swift */; };
 		8992A46022AF2E7400C186CA /* TileCoordsSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8992A45F22AF2E7400C186CA /* TileCoordsSpecs.swift */; };
 		899A5FED23786422008BEC30 /* MapCacheConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899A5FEC23786422008BEC30 /* MapCacheConfigTests.swift */; };
 		A1B2C3D4E5F60000000000A2 /* MapCache in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D4E5F60000000000A1 /* MapCache */; };
@@ -64,6 +65,7 @@
 		895E71B222C2EA140006977C /* RegionDownloaderSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionDownloaderSpecs.swift; sourceTree = "<group>"; };
 		895E71B722CB13090006977C /* DownloaderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloaderViewController.swift; sourceTree = "<group>"; };
 		897DE7ED22976D7E0054A9A1 /* MapCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCacheTests.swift; sourceTree = "<group>"; };
+		898B22152FFC4D750085039C /* CacheIndexSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheIndexSpecs.swift; sourceTree = "<group>"; };
 		8992A45F22AF2E7400C186CA /* TileCoordsSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileCoordsSpecs.swift; sourceTree = "<group>"; };
 		899A5FEC23786422008BEC30 /* MapCacheConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCacheConfigTests.swift; sourceTree = "<group>"; };
 		98B68CF07B3AC619DB7870E1 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 		893072CA22A47D36008612A1 /* DiskCache */ = {
 			isa = PBXGroup;
 			children = (
+				898B22152FFC4D750085039C /* CacheIndexSpecs.swift */,
 				893072CB22A47E4A008612A1 /* DiskCacheSpecs.swift */,
 				893072CD22A47F06008612A1 /* String+DiskCacheSpecs.swift */,
 			);
@@ -321,6 +324,7 @@
 				899A5FED23786422008BEC30 /* MapCacheConfigTests.swift in Sources */,
 				895E71B322C2EA140006977C /* RegionDownloaderSpecs.swift in Sources */,
 				895E719E22B34F2A0006977C /* ZoomRangeSpecs.swift in Sources */,
+				898B22162FFC4D750085039C /* CacheIndexSpecs.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/MapCache/ViewController.swift
+++ b/Example/MapCache/ViewController.swift
@@ -45,7 +45,10 @@ class ViewController: UIViewController {
         //
         //
         config.loadTileMode = .serverThenCache
-        
+    
+        // Set the capacity (in bytes), this limits the 
+        // maximum size of the cache. When the cache exceeds this size, the least recently used tiles are deleted.
+        config.capacity = 100_000_000 //100 MB
 
         // initialize the cache with our config
         mapCache = MapCache(withConfig: config)

--- a/Example/Tests/DiskCache/CacheIndexSpecs.swift
+++ b/Example/Tests/DiskCache/CacheIndexSpecs.swift
@@ -1,0 +1,121 @@
+//
+//  CacheIndexSpecs.swift
+//  MapCache_Tests
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import MapCache
+
+class CacheIndexSpecs: QuickSpec {
+
+    override func spec() {
+        describe("CacheIndex") {
+            var index: CacheIndex!
+
+            beforeEach {
+                index = CacheIndex()
+            }
+
+            it("starts empty") {
+                expect(index.totalSize).to(equal(0))
+                expect(index.count).to(equal(0))
+                expect(index.isEmpty) == true
+                expect(index.oldest).to(beNil())
+                expect(index.popOldest()).to(beNil())
+            }
+
+            it("can add an entry and keeps track of totalSize") {
+                index.add(filename: "abc", size: 4096)
+                expect(index.count).to(equal(1))
+                expect(index.isEmpty) == false
+                expect(index.totalSize).to(equal(4096))
+                expect(index.oldest?.filename).to(equal("abc"))
+                expect(index.oldest?.size).to(equal(4096))
+            }
+
+            it("can add an entry with a custom modification date") {
+                let past = Date(timeIntervalSince1970: 0)
+                index.add(filename: "old", size: 4096, modificationDate: past)
+                expect(index.oldest?.modificationDate).to(equal(past))
+            }
+
+            it("replaces existing entry on add with same filename") {
+                index.add(filename: "x", size: 4096)
+                index.add(filename: "x", size: 8192)
+                expect(index.count).to(equal(1))
+                expect(index.totalSize).to(equal(8192))
+            }
+
+            it("maintains entries sorted by modificationDate") {
+                let early = Date(timeIntervalSince1970: 100)
+                let late = Date(timeIntervalSince1970: 200)
+                index.add(filename: "b", size: 4096, modificationDate: late)
+                index.add(filename: "a", size: 4096, modificationDate: early)
+                expect(index.oldest?.filename).to(equal("a"))
+                expect(index.popOldest()?.filename).to(equal("a"))
+                expect(index.oldest?.filename).to(equal("b"))
+            }
+
+            it("touch updates modificationDate and re-sorts entries") {
+                index.add(filename: "x", size: 4096, modificationDate: Date(timeIntervalSince1970: 100))
+                index.add(filename: "y", size: 4096, modificationDate: Date(timeIntervalSince1970: 200))
+                expect(index.oldest?.filename).to(equal("x"))
+
+                index.touch(filename: "x", modificationDate: Date(timeIntervalSince1970: 300))
+                expect(index.oldest?.filename).to(equal("y"))
+            }
+
+            it("does nothing when touching a non-existent filename") {
+                index.touch(filename: "nonexistent")
+                expect(index.count).to(equal(0))
+                expect(index.totalSize).to(equal(0))
+            }
+
+            it("can remove an entry and keeps track of totalSize") {
+                index.add(filename: "a", size: 4096)
+                index.add(filename: "b", size: 8192)
+                expect(index.totalSize).to(equal(12288))
+
+                index.remove(filename: "a")
+                expect(index.count).to(equal(1))
+                expect(index.totalSize).to(equal(8192))
+                expect(index.oldest?.filename).to(equal("b"))
+            }
+
+            it("does nothing when removing a non-existent filename") {
+                index.add(filename: "a", size: 4096)
+                index.remove(filename: "nonexistent")
+                expect(index.count).to(equal(1))
+                expect(index.totalSize).to(equal(4096))
+            }
+
+            it("popOldest removes and returns the oldest entry") {
+                index.add(filename: "old", size: 4096, modificationDate: Date(timeIntervalSince1970: 100))
+                index.add(filename: "new", size: 8192, modificationDate: Date(timeIntervalSince1970: 200))
+
+                let entry = index.popOldest()
+                expect(entry?.filename).to(equal("old"))
+                expect(entry?.size).to(equal(4096))
+                expect(index.count).to(equal(1))
+                expect(index.totalSize).to(equal(8192))
+                expect(index.oldest?.filename).to(equal("new"))
+            }
+
+            it("popOldest returns nil when index is empty") {
+                expect(index.popOldest()).to(beNil())
+            }
+
+            it("removeAll clears all entries and resets totalSize") {
+                index.add(filename: "a", size: 4096)
+                index.add(filename: "b", size: 8192)
+                index.removeAll()
+                expect(index.count).to(equal(0))
+                expect(index.isEmpty) == true
+                expect(index.totalSize).to(equal(0))
+                expect(index.oldest).to(beNil())
+            }
+        }
+    }
+}

--- a/MapCache/Classes/DiskCache/CacheIndex.swift
+++ b/MapCache/Classes/DiskCache/CacheIndex.swift
@@ -66,6 +66,10 @@ open class CacheIndex {
     /// Mapping from filename to index in `entries`.
     private var entryMap: [String: Int] = [:]
 
+    /// Serializes all mutations so `touch` from any thread is safe with respect
+    /// to `controlCapacity()` running on `cacheQueue`.
+    private let lock = NSRecursiveLock()
+
     public init() {}
 
     /// Builds the index by enumerating the filesystem directory.
@@ -79,6 +83,8 @@ open class CacheIndex {
     /// - Returns: The total allocated size of all files found.
     @discardableResult
     open func build(from directoryURL: URL) -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
         entries = []
         entryMap = [:]
         totalSize = 0
@@ -118,6 +124,8 @@ open class CacheIndex {
     ///   - size: Allocated disk size in bytes.
     ///   - modificationDate: File modification date. Pass `nil` to use the current date.
     open func add(filename: String, size: UInt64, modificationDate: Date? = nil) {
+        lock.lock()
+        defer { lock.unlock() }
         let date = modificationDate ?? Date()
         remove(filename: filename)
 
@@ -138,6 +146,8 @@ open class CacheIndex {
     ///   - filename: MD5 filename of the cached file.
     ///   - modificationDate: New modification date. Pass `nil` to use the current date.
     open func touch(filename: String, modificationDate: Date? = nil) {
+        lock.lock()
+        defer { lock.unlock() }
         guard let idx = entryMap[filename] else { return }
         let date = modificationDate ?? Date()
         entries[idx].modificationDate = date
@@ -152,6 +162,8 @@ open class CacheIndex {
     ///
     /// - Parameter filename: MD5 filename of the cached file to remove.
     open func remove(filename: String) {
+        lock.lock()
+        defer { lock.unlock() }
         guard let idx = entryMap[filename] else { return }
         totalSize -= entries[idx].size
         entries.remove(at: idx)
@@ -163,6 +175,8 @@ open class CacheIndex {
 
     /// Removes all entries from the index and resets `totalSize` to zero.
     open func removeAll() {
+        lock.lock()
+        defer { lock.unlock() }
         entries = []
         entryMap = [:]
         totalSize = 0
@@ -172,6 +186,8 @@ open class CacheIndex {
     ///
     /// - Returns: The entry with the smallest `modificationDate`, or `nil` if the index is empty.
     open func popOldest() -> Entry? {
+        lock.lock()
+        defer { lock.unlock() }
         guard let oldest = oldest else { return nil }
         remove(filename: oldest.filename)
         return oldest
@@ -179,7 +195,7 @@ open class CacheIndex {
 
     /// Rebuilds the filename→index mapping from the sorted entries array.
     private func rebuildEntryMap() {
-        entryMap.removeAll(keepingCapacity: true)
+        entryMap = [:]
         for (i, entry) in entries.enumerated() {
             entryMap[entry.filename] = i
         }

--- a/MapCache/Classes/DiskCache/CacheIndex.swift
+++ b/MapCache/Classes/DiskCache/CacheIndex.swift
@@ -1,0 +1,187 @@
+//
+//  CacheIndex.swift
+//  MapCache
+//
+
+import Foundation
+
+/// In-memory sorted index of cache entries.
+///
+/// Maintains entries sorted by modification date ascending (oldest first).
+/// Provides O(log n) insertion via sort-after-append, O(1) lookup by filename,
+/// and O(n) removal with index shift. All mutations update `totalSize` atomically.
+///
+/// This class is intentionally standalone so multiple `DiskCache` instances or
+/// other consumers can share the same indexing logic without coupling to file I/O.
+///
+/// # Usage
+///
+/// ```swift
+/// let index = CacheIndex()
+///
+/// // Build from filesystem
+/// index.build(from: cacheURL)
+///
+/// // Track a new file
+/// index.add(filename: "abc123", size: 4096)
+///
+/// // Mark a file as recently accessed (moves it to the end of the sorted order)
+/// index.touch(filename: "abc123")
+///
+/// // Evict the oldest file
+/// if let entry = index.popOldest() {
+///     try? FileManager.default.removeItem(at: cacheURL.appendingPathComponent(entry.filename))
+/// }
+///
+/// // Remove a specific file
+/// index.remove(filename: "abc123")
+/// ```
+open class CacheIndex {
+
+    /// A single entry in the cache index.
+    public struct Entry: Equatable {
+        /// MD5 filename (file's `lastPathComponent` in the cache directory).
+        public let filename: String
+        /// Allocated disk size in bytes.
+        public var size: UInt64
+        /// Last modification date of the file.
+        public var modificationDate: Date
+    }
+
+    /// Total allocated disk size of all tracked entries, in bytes.
+    open private(set) var totalSize: UInt64 = 0
+
+    /// Number of entries in the index.
+    open var count: Int { entries.count }
+
+    /// Whether the index contains no entries.
+    open var isEmpty: Bool { entries.isEmpty }
+
+    /// The oldest entry (smallest `modificationDate`), or `nil` if the index is empty.
+    open var oldest: Entry? { entries.first }
+
+    /// All entries sorted by modification date ascending.
+    private var entries: [Entry] = []
+
+    /// Mapping from filename to index in `entries`.
+    private var entryMap: [String: Int] = [:]
+
+    public init() {}
+
+    /// Builds the index by enumerating the filesystem directory.
+    ///
+    /// Discards any existing index state and replaces it with the contents of
+    /// the directory. Each file's allocated size and modification date are read
+    /// via the resource keys `isRegularFileKey`, `fileAllocatedSizeKey`, and
+    /// `contentModificationDateKey`.
+    ///
+    /// - Parameter directoryURL: The cache directory URL to enumerate.
+    /// - Returns: The total allocated size of all files found.
+    @discardableResult
+    open func build(from directoryURL: URL) -> UInt64 {
+        entries = []
+        entryMap = [:]
+        totalSize = 0
+
+        let keys: Set<URLResourceKey> = [.isRegularFileKey, .fileAllocatedSizeKey, .contentModificationDateKey]
+        guard let enumerator = FileManager.default.enumerator(
+            at: directoryURL,
+            includingPropertiesForKeys: Array(keys),
+            options: .skipsSubdirectoryDescendants) else { return 0 }
+
+        for case let url as URL in enumerator {
+            guard let values = try? url.resourceValues(forKeys: keys),
+                  values.isRegularFile == true,
+                  let fileSize = values.fileAllocatedSize,
+                  let modDate = values.contentModificationDate else { continue }
+
+            let entry = Entry(filename: url.lastPathComponent,
+                              size: UInt64(fileSize),
+                              modificationDate: modDate)
+            entryMap[entry.filename] = entries.count
+            entries.append(entry)
+            totalSize += UInt64(fileSize)
+        }
+
+        entries.sort { $0.modificationDate < $1.modificationDate }
+        rebuildEntryMap()
+        return totalSize
+    }
+
+    /// Inserts or replaces an entry in the index.
+    ///
+    /// If an entry with the same `filename` already exists, it is removed first.
+    /// The entry's modification date defaults to the current date when `nil`.
+    ///
+    /// - Parameters:
+    ///   - filename: MD5 filename of the cached file.
+    ///   - size: Allocated disk size in bytes.
+    ///   - modificationDate: File modification date. Pass `nil` to use the current date.
+    open func add(filename: String, size: UInt64, modificationDate: Date? = nil) {
+        let date = modificationDate ?? Date()
+        remove(filename: filename)
+
+        let entry = Entry(filename: filename, size: size, modificationDate: date)
+        entries.append(entry)
+        totalSize += size
+
+        entries.sort { $0.modificationDate < $1.modificationDate }
+        rebuildEntryMap()
+    }
+
+    /// Updates the modification date of an existing entry.
+    ///
+    /// Does nothing if no entry with the given `filename` exists.
+    /// The modification date defaults to the current date when `nil`.
+    ///
+    /// - Parameters:
+    ///   - filename: MD5 filename of the cached file.
+    ///   - modificationDate: New modification date. Pass `nil` to use the current date.
+    open func touch(filename: String, modificationDate: Date? = nil) {
+        guard let idx = entryMap[filename] else { return }
+        let date = modificationDate ?? Date()
+        entries[idx].modificationDate = date
+
+        entries.sort { $0.modificationDate < $1.modificationDate }
+        rebuildEntryMap()
+    }
+
+    /// Removes an entry from the index by filename.
+    ///
+    /// Does nothing and does not produce an error if the filename is not in the index.
+    ///
+    /// - Parameter filename: MD5 filename of the cached file to remove.
+    open func remove(filename: String) {
+        guard let idx = entryMap[filename] else { return }
+        totalSize -= entries[idx].size
+        entries.remove(at: idx)
+        for i in idx..<entries.count {
+            entryMap[entries[i].filename] = i
+        }
+        entryMap.removeValue(forKey: filename)
+    }
+
+    /// Removes all entries from the index and resets `totalSize` to zero.
+    open func removeAll() {
+        entries = []
+        entryMap = [:]
+        totalSize = 0
+    }
+
+    /// Removes and returns the oldest entry.
+    ///
+    /// - Returns: The entry with the smallest `modificationDate`, or `nil` if the index is empty.
+    open func popOldest() -> Entry? {
+        guard let oldest = oldest else { return nil }
+        remove(filename: oldest.filename)
+        return oldest
+    }
+
+    /// Rebuilds the filename→index mapping from the sorted entries array.
+    private func rebuildEntryMap() {
+        entryMap.removeAll(keepingCapacity: true)
+        for (i, entry) in entries.enumerated() {
+            entryMap[entry.filename] = i
+        }
+    }
+}

--- a/MapCache/Classes/DiskCache/DiskCache.swift
+++ b/MapCache/Classes/DiskCache/DiskCache.swift
@@ -45,18 +45,16 @@ open class DiskCache {
     ///
     /// For example, a file may just contain 156 bytes of data (size listed in `ls` command), however its
     /// disk size is 4096, 1 volume block (as listed using `du -h`)
-    ///
-    /// This size is calculated each time
-    open var diskSize : UInt64 = 0
+    open var diskSize: UInt64 { index.totalSize }
     
-    /// This is the sum of the data sizes of the files within the `DiskCache`
-    ///
-    /// This size is calculated each time it is used
-    /// - Seealso: `diskSize`
-    
+    /// The sum of the data sizes of the files within the cache.
     open var fileSize: UInt64? {
         return try? FileManager.default.fileSizeForDirectory(at: folderURL)
     }
+    
+    /// In-memory index tracking all cached files, sorted by modification date.
+    /// Used by `controlCapacity()` for O(m) LRU eviction without filesystem scans.
+    private let index = CacheIndex()
     
     /// Maximum allowed cache disk allocated size for this `DiskCache``
     /// Defaults to unlimited capacity (`UINT64_MAX`)
@@ -91,7 +89,7 @@ open class DiskCache {
         }
         self.capacity = capacity
         cacheQueue.async(execute: {
-            self.diskSize = self.calculateDiskSize()
+            self.index.build(from: self.folderURL)
             self.controlCapacity()
         })
         //Log.diskcache.debug("folderURL=\(folderURL.absoluteString)")
@@ -113,23 +111,23 @@ open class DiskCache {
     
     /// Sets the data for the key synchronously.
     open func setDataSync(_ data: Data, forKey key: String) {
-        let filePath = path(forKey: key)
+        let filename = key.toMD5()
+        let filePath = folderURL.appendingPathComponent(filename).path
         Log.diskcache.debug("filePath: \(filePath) data count: \(data.count) key: \(key) diskBlocks:\(Double(data.count) / 4096.0)")
-        //If the file exists get the current file diskSize.
-        let fileURL = URL(fileURLWithPath: filePath)
-        do {
-            substract(diskSize: try fileURL.regularFileAllocatedDiskSize())
-        } catch {} //if file is not found do nothing
-        
+
+        index.remove(filename: filename)
+
         do {
             try data.write(to: URL(fileURLWithPath: filePath), options: Data.WritingOptions.atomicWrite)
         } catch {
             Log.diskcache.error("Failed to write key: \(key) filepath: \(filePath) \(error)")
+            return
         }
-        //Now add to the diskSize the file size
+
         var diskBlocks = Double(data.count) / 4096.0
         diskBlocks.round(.up)
-        diskSize += UInt64(diskBlocks * 4096.0)
+        let allocated = UInt64(diskBlocks * 4096.0)
+        index.add(filename: filename, size: allocated)
         self.controlCapacity()
     }
     
@@ -145,6 +143,7 @@ open class DiskCache {
             let data = try Data(contentsOf: URL(fileURLWithPath: path), options: Data.ReadingOptions())
             succeed(data)
             self.updateDiskAccessDate(atPath: path)
+            self.index.touch(filename: key.toMD5())
         } catch {
             if let block = fail {
                 block(error)
@@ -178,7 +177,7 @@ open class DiskCache {
                         Log.diskcache.error("Failed to remove path \(filePath) \(error)")
                     }
                 }
-                self.diskSize = self.calculateDiskSize()
+                self.index.removeAll()
                 Log.diskcache.debug("Size at the end \(self.diskSize)")
             } catch {
                 Log.diskcache.error("Failed to list directory \(error)")
@@ -208,8 +207,11 @@ open class DiskCache {
     open func updateAccessDate( _ getData: @autoclosure @escaping () -> Data?, key: String) {
         cacheQueue.async(execute: {
             let path = self.path(forKey: key)
+            let filename = key.toMD5()
             let fileManager = FileManager.default
-            if (!(fileManager.fileExists(atPath: path) && self.updateDiskAccessDate(atPath: path))){
+            if fileManager.fileExists(atPath: path) && self.updateDiskAccessDate(atPath: path) {
+                self.index.touch(filename: filename)
+            } else {
                 if let data = getData() {
                     self.setDataSync(data, forKey: key)
                 } else {
@@ -221,31 +223,16 @@ open class DiskCache {
     
     /// Calculates the size used by all the files in the cache.
     public func calculateDiskSize() -> UInt64 {
-        let fileManager = FileManager.default
-        var currentSize : UInt64 = 0
-        do {
-            currentSize = try fileManager.allocatedDiskSizeForDirectory(at: folderURL)
-        }
-        catch {
-            Log.diskcache.error("Failed to get diskSize of directory \(error)")
-        }
-        return currentSize
+        return index.build(from: folderURL)
     }
     
     // MARK: Private
     
     /// It checks if the capacity of the cache has been reached. If so, it removes the least recently used file (LRU).
     fileprivate func controlCapacity() {
-        if self.diskSize <= self.capacity { return }
-        
-        let fileManager = FileManager.default
-        let cachePath = self.path
-        fileManager.enumerateContentsOfDirectory(
-            atPath: cachePath,
-            orderedByProperty: URLResourceKey.contentModificationDateKey.rawValue, ascending: true) {
-                (URL : URL, _, stop : inout Bool) -> Void in
-                self.removeFile(atPath: URL.path)
-                stop = self.diskSize <= self.capacity
+        while index.totalSize > capacity, let oldest = index.popOldest() {
+            let filePath = folderURL.appendingPathComponent(oldest.filename).path
+            removeFile(atPath: filePath)
         }
     }
     /// Updates the time a file was accessed for the last time.
@@ -263,33 +250,20 @@ open class DiskCache {
     
     /// Removes a file syncrhonously.
     fileprivate func removeFile(atPath path: String) {
-        let fileManager = FileManager.default
+        let filename = URL(fileURLWithPath: path).lastPathComponent
         do {
-            let fileURL = URL(fileURLWithPath: path)
-            let fileSize = try fileURL.regularFileAllocatedDiskSize()
-            try fileManager.removeItem(atPath: path)
-            substract(diskSize: fileSize)
+            try FileManager.default.removeItem(atPath: path)
         } catch {
             if isNoSuchFileError(error) {
                 Log.diskcache.error("Failed to remove file. File not found \(error)")
             } else {
-                Log.diskcache.error("Failed to remove file. Size or other error \(error)")
+                Log.diskcache.error("Failed to remove file \(error)")
             }
         }
+        index.remove(filename: filename)
     }
     
-    /// Substracts from the cachesize  the disk size passed as parameter.
-    /// Logs an error message if the amount to be substracted is larger than the current used disk space.
-    ///
-    /// - Parameter diskSize: disksize to be deducted
-    fileprivate func substract(diskSize : UInt64) {
-        if (self.diskSize >= diskSize) {
-            self.diskSize -= diskSize
-        } else {
-            Log.diskcache.error("diskSize (\(self.diskSize)) is smaller than diskSize to substract (\(diskSize))")
-            self.diskSize = 0
-        }
-    }
+
 }
 
 /// Error when there is not a file.

--- a/MapCache/Classes/DiskCache/FileManager+DiskCache.swift
+++ b/MapCache/Classes/DiskCache/FileManager+DiskCache.swift
@@ -20,59 +20,6 @@ import Foundation
 ///
 extension FileManager {
     
-    /// Gets the list of files of this  the directory.
-    /// - Parameter atPath: path of the directory.
-    /// - Parameter orderedByProperty: property to be used for ordeing the contents.
-    /// - Parameter ascending: if true it is ordered ascending.
-    /// - Parameter usingBlock: block being used.
-    func enumerateContentsOfDirectory(atPath path: String, orderedByProperty property: String, ascending: Bool, usingBlock block: (URL, Int, inout Bool) -> Void ) {
-        
-        let directoryURL = URL(fileURLWithPath: path)
-        do {
-            let contents = try self.contentsOfDirectory(at: directoryURL, includingPropertiesForKeys: [URLResourceKey(rawValue: property)], options: FileManager.DirectoryEnumerationOptions())
-            let sortedContents = contents.sorted(by: {(URL1: URL, URL2: URL) -> Bool in
-                
-                // Maybe there's a better way to do this. See: http://stackoverflow.com/questions/25502914/comparing-anyobject-in-swift
-                
-                var value1 : AnyObject?
-                do {
-                    try (URL1 as NSURL).getResourceValue(&value1, forKey: URLResourceKey(rawValue: property))
-                } catch {
-                    return true
-                }
-                var value2 : AnyObject?
-                do {
-                    try (URL2 as NSURL).getResourceValue(&value2, forKey: URLResourceKey(rawValue: property))
-                } catch {
-                    return false
-                }
-                
-                if let string1 = value1 as? String, let string2 = value2 as? String {
-                    return ascending ? string1 < string2 : string2 < string1
-                }
-                
-                if let date1 = value1 as? Date, let date2 = value2 as? Date {
-                    return ascending ? date1 < date2 : date2 < date1
-                }
-                
-                if let number1 = value1 as? NSNumber, let number2 = value2 as? NSNumber {
-                    return ascending ? number1 < number2 : number2 < number1
-                }
-                
-                return false
-            })
-            
-            for (i, v) in sortedContents.enumerated() {
-                var stop : Bool = false
-                block(v, i, &stop)
-                if stop { break }
-            }
-            
-        } catch {
-            Log.diskcache.error("Failed to list directory \(error)")
-        }
-    }
-    
     /// Calculate the allocated size of a directory and all its contents on the volume.
     ///
     /// As there's no simple way to get this information from the file system the method


### PR DESCRIPTION
As discussed in #39, when the number of files is large in the cache and evictions start to appear, the cache is loading the whole folder which takes time and memory resulting in a memory allocation growth. 

## Implemented solution: In-memory sorted index for LRU eviction

Replaces the full-directory-scan eviction in DiskCache.controlCapacity() with an in-memory sorted index (CacheIndex) that tracks all cached files by modification date.

Closes #39 