### PR TITLE
Feature: Consistent access to sizes (MapCache.diskSize and MapCache.fileSize)

### DIFF
--- a/Example/MapCache/ViewController.swift
+++ b/Example/MapCache/ViewController.swift
@@ -66,13 +66,13 @@ class ViewController: UIViewController {
     
     @IBAction func updateSize(_ sender: Any) {
         print("update cache size")
-        cacheSizeLabel.text = String(mapCache!.calculateDiskSize())
+        cacheSizeLabel.text = String(mapCache!.diskSize)
     }
     
     @IBAction func clearCache(_ sender: Any) {
         print("clear cache")
         mapCache!.clear() { 
-            self.cacheSizeLabel.text = String(self.mapCache!.calculateDiskSize())
+            self.cacheSizeLabel.text = String(self.mapCache!.diskSize)
         }
     }
     

--- a/Example/Tests/DiskCache/DiskCacheSpecs.swift
+++ b/Example/Tests/DiskCache/DiskCacheSpecs.swift
@@ -90,14 +90,12 @@ class DiskCacheSpecs: QuickSpec {
             }
             
             it("keeps track of its disk size") {
-                let diskSize = diskCache.calculateDiskSize()
-                expect(diskSize) == 0
                 expect(diskCache.diskSize).to(equal(0))
                 diskCache.setDataSync(data1!, forKey: filename1)
                 // Note that 1 file ad minimum uses 4096 bytes in disk which is the
                 // block size.
                 // The actual content is only 10 bytes.
-                expect(diskCache.calculateDiskSize()).toEventually(equal(4096))
+                expect(diskCache.diskSize).toEventually(equal(4096))
             }
             
             it("keeps track of its file size") {
@@ -135,7 +133,7 @@ class DiskCacheSpecs: QuickSpec {
                 let filePath = diskCache.path(forKey: weird1)
                 expect(FileManager.default.fileExists(atPath: filePath)).to(equal(true))
                
-                expect(diskCache.calculateDiskSize()).to(equal(4096))
+                expect(diskCache.diskSize).to(equal(4096))
                 
                 var result: Data?
                 diskCache.fetchDataSync(forKey: weird1, failure: nil, success: {
@@ -171,7 +169,7 @@ class DiskCacheSpecs: QuickSpec {
                 diskCache.setDataSync(data1!, forKey: longFileName)
                 expect(diskCache.diskSize).to(equal(8192))
                 diskCache.removeAllData({})
-                expect(diskCache.calculateDiskSize()).toEventually(equal(0))
+                expect(diskCache.diskSize).toEventually(equal(0))
             }
             
         }

--- a/Example/Tests/MapCacheTests.swift
+++ b/Example/Tests/MapCacheTests.swift
@@ -58,6 +58,19 @@ class MapCacheTests: QuickSpec {
             let cache = MapCache(withConfig: config)
             let path = MKTileOverlayPath(x: 1, y: 2, z: 3, contentScaleFactor: 1.0)
             
+            it("reports fileSize via diskCache") {
+                let key = cache.cacheKey(forPath: path)
+                let data = "1234567890".data(using: .utf8)!
+                expect(cache.fileSize).toEventually(equal(0))
+                cache.diskCache.setDataSync(data, forKey: key)
+                expect(cache.fileSize).toEventually(equal(10))
+                expect(cache.fileSize).to(equal(cache.diskCache.fileSize))
+            }
+            
+            it("reports diskSize via diskCache") {
+                expect(cache.diskSize).to(equal(cache.diskCache.diskSize))
+            }
+            
             it("can create the tile url") {
                 let url = cache.url(forTilePath: path)
                 expect(url.absoluteString) == "https://localhost/ok/1/2/3"

--- a/Example/Tests/MapCacheTests.swift
+++ b/Example/Tests/MapCacheTests.swift
@@ -59,12 +59,21 @@ class MapCacheTests: QuickSpec {
             let path = MKTileOverlayPath(x: 1, y: 2, z: 3, contentScaleFactor: 1.0)
             
             it("reports fileSize via diskCache") {
-                let key = cache.cacheKey(forPath: path)
+                // createa a new empty cache
+                let sizeName = "fileSizeTest_\(Int.random(in: 1..<100000000))"
+                var sizeConfig = MapCacheConfig(withUrlTemplate: urlTemplate)
+                sizeConfig.cacheName = sizeName
+                sizeConfig.subdomains = ["ok"]
+                let sizeCache = MapCache(withConfig: sizeConfig)
+                defer { sizeCache.diskCache.removeCache() }
+                // check is empty
+                expect(sizeCache.fileSize).toEventually(equal(0))
+                // Add 10 bytes of data
                 let data = "1234567890".data(using: .utf8)!
-                expect(cache.fileSize).toEventually(equal(0))
-                cache.diskCache.setDataSync(data, forKey: key)
-                expect(cache.fileSize).toEventually(equal(10))
-                expect(cache.fileSize).to(equal(cache.diskCache.fileSize))
+                sizeCache.diskCache.setDataSync(data, forKey: "test")
+                // check it was added
+                expect(sizeCache.fileSize).toEventually(equal(10))
+                expect(sizeCache.fileSize).to(equal(sizeCache.diskCache.fileSize))
             }
             
             it("reports diskSize via diskCache") {
@@ -214,7 +223,7 @@ class MapCacheTests: QuickSpec {
             }
 
             it("clear removes both caches") {
-                let (localCache, localPath, localKey) = makeCache(host: "localhost")
+                let (localCache, _, localKey) = makeCache(host: "localhost")
 
                 localCache.diskCache.setDataSync("some-data".data(using: .utf8)!, forKey: localKey)
                 localCache.etagCache.setDataSync("some-etag".data(using: .utf8)!, forKey: localKey)

--- a/MapCache/Classes/DiskCache/DiskCache.swift
+++ b/MapCache/Classes/DiskCache/DiskCache.swift
@@ -222,6 +222,7 @@ open class DiskCache {
     }
     
     /// Calculates the size used by all the files in the cache.
+    @available(*, deprecated, renamed: "diskSize")
     public func calculateDiskSize() -> UInt64 {
         return index.build(from: folderURL)
     }

--- a/MapCache/Classes/MapCache.swift
+++ b/MapCache/Classes/MapCache.swift
@@ -223,18 +223,17 @@ open class MapCache : MapCacheProtocol {
         }
     }
     
-    //TODO review why does it have two ways of retrieving the cache size.
-    
-    /// Currently size of the cache
-    public var diskSize: UInt64 {
-        get  {
-            return diskCache.diskSize
-        }
+    /// Logical data size of the cache (sum of file data sizes, not allocated blocks).
+    public var fileSize: UInt64? {
+        return diskCache.fileSize
     }
     
-    /// Calculates the disk space allocated in dis for the cache
-    /// 
-    /// - SeeAlso: DiskCache
+    /// Currently allocated size of the cache (disk blocks).
+    public var diskSize: UInt64 {
+        return diskCache.diskSize
+    }
+    
+    @available(*, deprecated, renamed: "diskSize")
     public func calculateDiskSize() -> UInt64 {
         return diskCache.calculateDiskSize()
     }


### PR DESCRIPTION
Implements #14.

* Added a new `fileSize` property to `MapCache` that returns the logical data size of the cache (sum of file data sizes, not allocated blocks).
* Clarified the `diskSize` property to represent the currently allocated disk blocks for the cache and updated its documentation. 
* Deprecated the `calculateDiskSize()` method in both `DiskCache` and `MapCache`, recommending use of the `diskSize` property instead. 
* Updated `ViewController.swift` to use the new `diskSize` property instead of the deprecated `calculateDiskSize()` method when displaying cache size.
