### PR TITLE
Feature: Enhance the variety of delegate notifications in region downloader

### DIFF
--- a/Example/MapCache.xcodeproj/project.pbxproj
+++ b/Example/MapCache.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		895E71B822CB13090006977C /* DownloaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895E71B722CB13090006977C /* DownloaderViewController.swift */; };
 		897DE7EE22976D7E0054A9A1 /* MapCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897DE7ED22976D7E0054A9A1 /* MapCacheTests.swift */; };
 		898B22162FFC4D750085039C /* CacheIndexSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898B22152FFC4D750085039C /* CacheIndexSpecs.swift */; };
+		898B22182FFD7F2A0085039C /* RegionDownloaderDelegateSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898B22172FFD7F2A0085039C /* RegionDownloaderDelegateSpecs.swift */; };
 		8992A46022AF2E7400C186CA /* TileCoordsSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8992A45F22AF2E7400C186CA /* TileCoordsSpecs.swift */; };
 		899A5FED23786422008BEC30 /* MapCacheConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899A5FEC23786422008BEC30 /* MapCacheConfigTests.swift */; };
 		A1B2C3D4E5F60000000000A2 /* MapCache in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D4E5F60000000000A1 /* MapCache */; };
@@ -66,6 +67,7 @@
 		895E71B722CB13090006977C /* DownloaderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloaderViewController.swift; sourceTree = "<group>"; };
 		897DE7ED22976D7E0054A9A1 /* MapCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCacheTests.swift; sourceTree = "<group>"; };
 		898B22152FFC4D750085039C /* CacheIndexSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheIndexSpecs.swift; sourceTree = "<group>"; };
+		898B22172FFD7F2A0085039C /* RegionDownloaderDelegateSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionDownloaderDelegateSpecs.swift; sourceTree = "<group>"; };
 		8992A45F22AF2E7400C186CA /* TileCoordsSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileCoordsSpecs.swift; sourceTree = "<group>"; };
 		899A5FEC23786422008BEC30 /* MapCacheConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCacheConfigTests.swift; sourceTree = "<group>"; };
 		98B68CF07B3AC619DB7870E1 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				895E71A122B49A4C0006977C /* TileRangeSpecs.swift */,
 				895E71A322B50E6B0006977C /* TileRegionSpecs.swift */,
 				895E71B222C2EA140006977C /* RegionDownloaderSpecs.swift */,
+				898B22172FFD7F2A0085039C /* RegionDownloaderDelegateSpecs.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -316,6 +319,7 @@
 			files = (
 				895E71A422B50E6B0006977C /* TileRegionSpecs.swift in Sources */,
 				895E71A222B49A4C0006977C /* TileRangeSpecs.swift in Sources */,
+				898B22182FFD7F2A0085039C /* RegionDownloaderDelegateSpecs.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* Tests.swift in Sources */,
 				893072CC22A47E4A008612A1 /* DiskCacheSpecs.swift in Sources */,
 				893072CE22A47F06008612A1 /* String+DiskCacheSpecs.swift in Sources */,

--- a/Example/MapCache.xcodeproj/xcshareddata/xcschemes/MapCache-Example.xcscheme
+++ b/Example/MapCache.xcodeproj/xcshareddata/xcschemes/MapCache-Example.xcscheme
@@ -71,11 +71,6 @@
                BlueprintName = "MapCache_Tests"
                ReferencedContainer = "container:MapCache.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "MapCacheTests2">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Example/MapCache/Base.lproj/Main.storyboard
+++ b/Example/MapCache/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -27,17 +27,17 @@
                                 <rect key="frame" x="0.0" y="0.0" width="500" height="99"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7EQ-Hp-CVK">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7EQ-Hp-CVK">
                                         <rect key="frame" x="122" y="48" width="71" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" cocoaTouchSystemColor="lightTextColor"/>
+                                        <color key="backgroundColor" systemColor="lightTextColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <state key="normal" title="Clear"/>
                                         <connections>
                                             <action selector="clearCache:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="m3S-Qp-RDR"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="w0Z-in-k23" userLabel="Update Size Button">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="w0Z-in-k23" userLabel="Update Size Button">
                                         <rect key="frame" x="0.0" y="69" width="116" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <accessibility key="accessibilityConfiguration" hint="updates value of the cache size" label="Update Size">
@@ -49,7 +49,7 @@
                                             <action selector="updateSize:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="3FC-cx-Tx6"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wOt-Fe-b8G">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wOt-Fe-b8G">
                                         <rect key="frame" x="201" y="48" width="149" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -101,7 +101,7 @@
                         <viewControllerLayoutGuide type="bottom" id="ccj-19-m1N"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="ezZ-5I-yxf">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="657"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dId-17-Wac">
@@ -118,16 +118,16 @@
                                 </items>
                             </navigationBar>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="gul-O5-AUM">
-                                <rect key="frame" x="0.0" y="72" width="375" height="505"/>
+                                <rect key="frame" x="0.0" y="72" width="375" height="495"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             </mapView>
                             <view alpha="0.30000001192092896" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mhf-Xv-732" userLabel="Right Border View">
-                                <rect key="frame" x="350" y="72" width="25" height="404"/>
+                                <rect key="frame" x="350" y="72" width="25" height="395"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view alpha="0.29999999999999999" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r81-lv-Rwe" userLabel="Left Border View">
-                                <rect key="frame" x="0.0" y="72" width="26" height="404"/>
+                                <rect key="frame" x="0.0" y="72" width="26" height="395"/>
                                 <autoresizingMask key="autoresizingMask" heightSizable="YES"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <rect key="contentStretch" x="0.0" y="1" width="1" height="1"/>
@@ -138,52 +138,52 @@
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view alpha="0.29999999999999999" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAQ-zq-8WQ" userLabel="Bottom Border View">
-                                <rect key="frame" x="0.0" y="476" width="375" height="37"/>
+                                <rect key="frame" x="-6" y="467" width="381" height="35"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <rect key="contentStretch" x="0.0" y="1" width="1" height="1"/>
                             </view>
                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="abU-YW-u0D">
-                                <rect key="frame" x="0.0" y="577" width="375" height="2"/>
+                                <rect key="frame" x="0.0" y="568" width="375" height="2"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                             </progressView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NZm-44-4an">
-                                <rect key="frame" x="0.0" y="583" width="375" height="64"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
-                                <state key="normal" title="Download Region"/>
-                                <connections>
-                                    <action selector="downloadRegion:" destination="kyc-CB-ghz" eventType="touchUpInside" id="8cr-C9-Z7y"/>
-                                </connections>
-                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="For Testing only. OpenStreetMaps does not allow predonwload regions. (aprox. 500 tiles works fine)" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gc8-FU-iPu">
-                                <rect key="frame" x="0.0" y="476" width="375" height="37"/>
+                                <rect key="frame" x="0.0" y="461" width="375" height="37"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.0" alpha="0.90000000000000002" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view alpha="0.75" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fDV-Bg-6Ys" userLabel="Bottom Border View">
-                                <rect key="frame" x="1" y="511" width="375" height="68"/>
+                                <rect key="frame" x="1" y="502" width="375" height="65"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                 <subviews>
                                     <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="11" minValue="1" maxValue="19" translatesAutoresizingMaskIntoConstraints="NO" id="qMo-0h-Hge">
-                                        <rect key="frame" x="23" y="39" width="328" height="30"/>
+                                        <rect key="frame" x="23" y="36" width="328" height="30"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <connections>
                                             <action selector="sliderValueChanged:" destination="kyc-CB-ghz" eventType="valueChanged" id="bEg-w0-eKi"/>
                                         </connections>
                                     </slider>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="_" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pIw-AR-t92">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="28"/>
+                                        <rect key="frame" x="13" y="0.0" width="375" height="28"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <color key="textColor" cocoaTouchSystemColor="tableCellGroupedBackgroundColor"/>
+                                        <color key="textColor" systemColor="tableCellGroupedBackgroundColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                                 <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <rect key="contentStretch" x="0.0" y="1" width="1" height="1"/>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NZm-44-4an">
+                                <rect key="frame" x="0.0" y="575" width="217" height="52"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
+                                <state key="normal" title="Download Region"/>
+                                <connections>
+                                    <action selector="downloadRegion:" destination="kyc-CB-ghz" eventType="touchUpInside" id="8cr-C9-Z7y"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
@@ -200,4 +200,12 @@
             <point key="canvasLocation" x="893.60000000000002" y="114.69265367316342"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="lightTextColor">
+            <color white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="tableCellGroupedBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/MapCache/DownloaderViewController.swift
+++ b/Example/MapCache/DownloaderViewController.swift
@@ -21,6 +21,15 @@ class DownloaderViewController: UIViewController {
     
     @IBOutlet weak var downloadButton: UIButton!
     
+    /// Label that displays the download progress.
+    var statusLabel: UILabel!
+    
+    /// Pause button to stop the download.
+    var pauseButton: UIButton!
+    
+    /// Current downloader instance.
+    var regionDownloader: RegionDownloader?
+    
     /// region to download.
     var region : TileCoordsRegion?
     
@@ -57,20 +66,58 @@ class DownloaderViewController: UIViewController {
         print("*** Actual path where the files are stored: \(mapCache?.diskCache.path ?? "No disk cache path")")
        
 
-        // Initialize the region with any random value.
+        // Initialize region from current map view and slider default zoom.
         region = TileCoordsRegion(topLeftLatitude: 10.0, topLeftLongitude: 10.0, bottomRightLatitude: 20.0, bottomRightLongitude: 20.0, minZoom: 1, maxZoom: 9)
+        slider.value = 10
+        updateRegion()
+        
+        // Setup status label for download progress
+        statusLabel = UILabel(frame: CGRect(x: 0, y: progressView.frame.minY - 20, width: view.frame.width, height: 18))
+        statusLabel.textAlignment = .center
+        statusLabel.font = .systemFont(ofSize: 13)
+        statusLabel.textColor = .darkGray
+        statusLabel.text = ""
+        view.addSubview(statusLabel)
+        
+        // Setup pause button below the slider, right-aligned
+        let sliderFrame = view.convert(slider.frame, from: slider.superview)
+        pauseButton = UIButton(type: .system)
+        pauseButton.frame = CGRect(x: view.frame.width - 100, y: sliderFrame.maxY - 50, width: 60, height: 28)
+        pauseButton.setTitle("Pause", for: .normal)
+        pauseButton.backgroundColor = .systemBlue
+        pauseButton.setTitleColor(.white, for: .normal)
+        pauseButton.layer.cornerRadius = 6
+        pauseButton.titleLabel?.font = .systemFont(ofSize: 13)
+        pauseButton.addTarget(self, action: #selector(togglePause), for: .touchUpInside)
+        pauseButton.isHidden = true
+        view.addSubview(pauseButton)
     }
     
     
     /// Activated when download region button is pressed
     @IBAction func downloadRegion(_ sender: Any) {
         print("Download Region Pressed!")
-        
 
         let downloader = RegionDownloader(forRegion: region!, mapCache: mapCache!)
-        let delegate = self
-        downloader.delegate = delegate
+        downloader.delegate = self
+        regionDownloader = downloader
+        pauseButton.setTitle("Pause", for: .normal)
+        pauseButton.isHidden = false
         downloader.start()
+    }
+
+    /// Toggles between pause and resume.
+    @objc func togglePause() {
+        guard let downloader = regionDownloader else { return }
+        if pauseButton.title(for: .normal) == "Pause" {
+            downloader.stop()
+            pauseButton.setTitle("Resume", for: .normal)
+            statusLabel.text = "Download paused"
+        } else {
+            downloader.resume()
+            pauseButton.setTitle("Pause", for: .normal)
+            statusLabel.text = "Resuming download..."
+        }
     }
     
     /// Slider changed its value
@@ -123,19 +170,36 @@ extension DownloaderViewController : MKMapViewDelegate {
 }
 
 extension DownloaderViewController : RegionDownloaderDelegate {
-    
+
     func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadPercentage percentage: Double) {
          DispatchQueue.main.async {
             self.progressView.progress = Float(percentage / 100.0)
         }
-        
     }
-    
+
     func regionDownloader(_ regionDownloader: RegionDownloader, didFinishDownload tilesDownloaded: TileNumber) {
         DispatchQueue.main.async {
             self.progressView.progress = 1.0
+            self.statusLabel.text = "Downloaded: \(regionDownloader.successfulTileDownloads)/\(regionDownloader.totalTilesToDownload) tiles | Failed: \(regionDownloader.failedTileDownloads)"
+            self.pauseButton.isHidden = true
         }
     }
-    
-    
+
+    func regionDownloader(_ regionDownloader: RegionDownloader, willStartDownloading totalTiles: TileNumber, region: TileCoordsRegion, mapCache: MapCacheProtocol) {
+        DispatchQueue.main.async {
+            self.statusLabel.text = "Starting download of \(totalTiles) tiles..."
+        }
+    }
+
+    func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadTileAt tileCoords: TileCoords, dataSize: Int) {
+        DispatchQueue.main.async {
+            self.statusLabel.text = "Downloaded: \(regionDownloader.successfulTileDownloads)/\(regionDownloader.totalTilesToDownload) tiles | Failed: \(regionDownloader.failedTileDownloads)"
+        }
+    }
+
+    func regionDownloader(_ regionDownloader: RegionDownloader, didFailToDownloadTileAt tileCoords: TileCoords, error: Error) {
+        DispatchQueue.main.async {
+            self.statusLabel.text = "Downloaded: \(regionDownloader.successfulTileDownloads)/\(regionDownloader.totalTilesToDownload) tiles | Failed: \(regionDownloader.failedTileDownloads)"
+        }
+    }
 }

--- a/Example/Tests/RegionDownloaderDelegateSpecs.swift
+++ b/Example/Tests/RegionDownloaderDelegateSpecs.swift
@@ -1,0 +1,115 @@
+//
+//  RegionDownloaderDelegateSpecs.swift
+//  MapCache_Tests
+//
+//  Created by merlos on 07/07/2026.
+//  Copyright © 2026 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+import MapKit
+@testable import MapCache
+
+class DelegateTest : RegionDownloaderDelegate {
+
+    public var finished = false
+    public var startCallCount = 0
+    public var startTotalTiles: TileNumber = 0
+    public var successCallCount = 0
+    public var successCoords: [TileCoords] = []
+    public var failureCallCount = 0
+    public var failureCoords: [TileCoords] = []
+
+    func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadPercentage percentage: Double) {
+        print("didDownloadPercentage")
+    }
+
+    func regionDownloader(_ regionDownloader: RegionDownloader, didFinishDownload tilesDownloaded: TileNumber) {
+        print("FinishDonwload")
+        finished = true
+    }
+
+    func regionDownloader(_ regionDownloader: RegionDownloader, willStartDownloading totalTiles: TileNumber, region: TileCoordsRegion, mapCache: MapCacheProtocol) {
+        startCallCount += 1
+        startTotalTiles = totalTiles
+    }
+
+    func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadTileAt tileCoords: TileCoords, dataSize: Int) {
+        successCallCount += 1
+        successCoords.append(tileCoords)
+    }
+
+    func regionDownloader(_ regionDownloader: RegionDownloader, didFailToDownloadTileAt tileCoords: TileCoords, error: Error) {
+        failureCallCount += 1
+        failureCoords.append(tileCoords)
+    }
+}
+
+class RegionDownloaderDelegateSpecs: QuickSpec {
+    override func spec() {
+        describe("RegionDownloaderDelegate") {
+
+            let mapCacheMock = MapCacheMock()
+            let topLeft = TileCoords(latitude: 20.0, longitude: 10.0, zoom: 10)!
+            let bottomRight = TileCoords(latitude: 10.0, longitude: 20.0, zoom: 10)!
+            let region = TileCoordsRegion(topLeft: topLeft, bottomRight: bottomRight)!
+
+            it("calls willStartDownloading before starting") {
+                let downloader = RegionDownloader(forRegion: region, mapCache: mapCacheMock)
+                let delegate = DelegateTest()
+                downloader.delegate = delegate
+                downloader.start()
+                expect(delegate.startCallCount).toEventually(equal(1), timeout: .seconds(10))
+                expect(delegate.startTotalTiles).to(equal(region.count))
+            }
+
+            it("calls didDownloadTileAt for each tile on success") {
+                mapCacheMock.resultType = .data
+                mapCacheMock.counter = 0
+                let downloader = RegionDownloader(forRegion: region, mapCache: mapCacheMock)
+                let delegate = DelegateTest()
+                downloader.delegate = delegate
+                downloader.start()
+                expect(delegate.finished).toEventually(beTrue(), timeout: .seconds(10))
+                expect(delegate.successCallCount).to(equal(Int(region.count)))
+                expect(delegate.failureCallCount).to(equal(0))
+            }
+
+            it("calls didFailToDownloadTileAt for each tile on error") {
+                mapCacheMock.resultType = .error
+                mapCacheMock.counter = 0
+                let downloader = RegionDownloader(forRegion: region, mapCache: mapCacheMock)
+                let delegate = DelegateTest()
+                downloader.delegate = delegate
+                downloader.start()
+                expect(delegate.finished).toEventually(beTrue(), timeout: .seconds(10))
+                expect(delegate.failureCallCount).to(equal(Int(region.count)))
+                expect(delegate.successCallCount).to(equal(0))
+            }
+
+            it("passes correct tile zoom in success callbacks") {
+                mapCacheMock.resultType = .data
+                mapCacheMock.counter = 0
+                let downloader = RegionDownloader(forRegion: region, mapCache: mapCacheMock)
+                let delegate = DelegateTest()
+                downloader.delegate = delegate
+                downloader.start()
+                expect(delegate.finished).toEventually(beTrue(), timeout: .seconds(10))
+                expect(delegate.successCoords.first?.zoom).to(equal(10))
+            }
+
+            it("passes correct tile zoom in failure callbacks") {
+                mapCacheMock.resultType = .error
+                mapCacheMock.counter = 0
+                let downloader = RegionDownloader(forRegion: region, mapCache: mapCacheMock)
+                let delegate = DelegateTest()
+                downloader.delegate = delegate
+                downloader.start()
+                expect(delegate.finished).toEventually(beTrue(), timeout: .seconds(10))
+                expect(delegate.failureCoords.first?.zoom).to(equal(10))
+            }
+        }
+    }
+}

--- a/Example/Tests/RegionDownloaderSpecs.swift
+++ b/Example/Tests/RegionDownloaderSpecs.swift
@@ -52,6 +52,7 @@ class MapCacheMock : MapCacheProtocol {
         case .mixed:
             if (counter % errorEvery) == 0 {
                 result(nil, error)
+                return
             }
             result(data, nil)
         case .data:
@@ -60,20 +61,6 @@ class MapCacheMock : MapCacheProtocol {
         case .error:
             result(nil, error)
         }
-    }
-}
-
-class DelegateTest : RegionDownloaderDelegate {
-    
-    public var finished = false
-    
-    func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadPercentage percentage: Double) {
-        print("didDownloadPercentage")
-    }
-    
-    func regionDownloader(_ regionDownloader: RegionDownloader, didFinishDownload tilesDownloaded: TileNumber) {
-        print("FinishDonwload")
-        finished = true
     }
 }
 
@@ -98,15 +85,6 @@ class RegionDownloaderSpecs: QuickSpec {
                 expect(downloader.failedTileDownloads).to(equal(0))
             }
             
-            it("counts downloaded tiles ok") {
-                let mapCacheMock = MapCacheMock()
-                let downloader = RegionDownloader(forRegion: region, mapCache: mapCacheMock)
-                let delegate = DelegateTest()
-                downloader.delegate = delegate
-                downloader.start()
-                expect(delegate.finished).toEventually(beTrue(), timeout: .seconds(10))
-
-            }
         }
     }
 }

--- a/MapCache/Classes/RegionDownloader.swift
+++ b/MapCache/Classes/RegionDownloader.swift
@@ -66,6 +66,9 @@ import MapKit
 
     /// Indicates that the download has been paused due to too many concurrent downloads. The downloader will automatically try after timeout.
     private var _stopped = false
+
+    /// Tracks already processed tiles to avoid double-counting on resume.
+    private var _processedTileKeys: Set<String> = []
     
     /// Total number of downloaded data bytes.
     public var downloadedBytes: UInt64 {
@@ -168,20 +171,42 @@ import MapKit
         _failedTileDownloads = 0
         lastPercentageNotified = 0.0
         nextPercentageToNotify = incrementInPercentageNotification
+        _processedTileKeys.removeAll()
     }
     
     /// Starts download.
     public func start() {
-        //Downloads stuff
         resetCounters()
+        downloadLoop()
+    }
+
+    /// Resumes a paused download without resetting counters.
+    public func resume() {
+        guard _stopped else { return }
+        _stopped = false
+        downloadLoop(isResume: true)
+    }
+
+    /// Stop download.
+    public func stop() {
+        _stopped = true
+    }
+
+    private func downloadLoop(isResume: Bool = false) {
         downloaderQueue.async {
-            self.delegate?.regionDownloader(self, willStartDownloading: self.totalTilesToDownload, region: self.region, mapCache: self.mapCache)
-            /// Limit the number of tasks
+            if !isResume {
+                self.delegate?.regionDownloader(self, willStartDownloading: self.totalTilesToDownload, region: self.region, mapCache: self.mapCache)
+            }
             let semaphore = DispatchSemaphore(value: self.maxConcurrentDownloads)
             for range: TileRange in self.region.tileRanges() ?? [] {
                 for tileCoords: TileCoords in range {
                     if self._stopped {
                         return
+                    }
+                    // Skip already processed tiles (relevant on resume)
+                    let key = "\(tileCoords.zoom)-\(tileCoords.tileX)-\(tileCoords.tileY)"
+                    if self._processedTileKeys.contains(key) {
+                        continue
                     }
                     while semaphore.wait(timeout: DispatchTime(after: self.downloadTimeout)) == .timedOut {
                         if self._stopped {
@@ -189,32 +214,28 @@ import MapKit
                         }
                     }
 
-                    ///Add to the download queue.
                     let mktileOverlayPath = MKTileOverlayPath(tileCoords: tileCoords)
                     self.mapCache.loadTile(at: mktileOverlayPath, result: { data, error in
                         semaphore.signal()
+                        let key = "\(tileCoords.zoom)-\(tileCoords.tileX)-\(tileCoords.tileY)"
+                        guard !self._processedTileKeys.contains(key) else { return }
+                        self._processedTileKeys.insert(key)
+
                         if error != nil {
                             Log.downloader.error("\(error?.localizedDescription ?? "Error downloading tile")")
                             self._failedTileDownloads += 1
                             self.delegate?.regionDownloader(self, didFailToDownloadTileAt: tileCoords, error: error!)
-                            // TODO add to an array of tiles not downloaded
-                            // so a retry can be performed
                         } else {
                             self._successfulTileDownloads += 1
                             self._downloadedBytes += UInt64(data?.count ?? 0)
                             self.delegate?.regionDownloader(self, didDownloadTileAt: tileCoords, dataSize: data?.count ?? 0)
                             Log.downloader.debug("Donwloaded zoom: \(tileCoords.zoom) (x:\(tileCoords.tileX),y:\(tileCoords.tileY), data.count: \(data?.count ?? 0)) \(self.downloadedTiles)/\(self.totalTilesToDownload) \(self.downloadedPercentage)%, bytes: \(self.downloadedBytes), average tile size: \(self.averageTileSizeBytes)")
-                            
                         }
-                        //check if needs to notify duet to percentage
                         if self.downloadedPercentage > self.nextPercentageToNotify {
-                            //Update status variables
                             self.lastPercentageNotified = self.nextPercentageToNotify
                             self.nextPercentageToNotify += self.incrementInPercentageNotification
-                            //call the delegate
                             self.delegate?.regionDownloader(self, didDownloadPercentage: self.downloadedPercentage)
                         }
-                        //Did we finish download
                         if self.downloadedTiles == self.totalTilesToDownload {
                             self.delegate?.regionDownloader(self, didFinishDownload: self.downloadedTiles)
                         }
@@ -222,11 +243,6 @@ import MapKit
                 }
             }
         }
-    }
-    
-    /// Stop download.
-    public func stop() {
-        _stopped = true
     }
     
     /// Returns an estimation of the total number of bytes the whole region may occupy.

--- a/MapCache/Classes/RegionDownloader.swift
+++ b/MapCache/Classes/RegionDownloader.swift
@@ -175,6 +175,7 @@ import MapKit
         //Downloads stuff
         resetCounters()
         downloaderQueue.async {
+            self.delegate?.regionDownloader(self, willStartDownloading: self.totalTilesToDownload, region: self.region, mapCache: self.mapCache)
             /// Limit the number of tasks
             let semaphore = DispatchSemaphore(value: self.maxConcurrentDownloads)
             for range: TileRange in self.region.tileRanges() ?? [] {
@@ -195,11 +196,13 @@ import MapKit
                         if error != nil {
                             Log.downloader.error("\(error?.localizedDescription ?? "Error downloading tile")")
                             self._failedTileDownloads += 1
+                            self.delegate?.regionDownloader(self, didFailToDownloadTileAt: tileCoords, error: error!)
                             // TODO add to an array of tiles not downloaded
                             // so a retry can be performed
                         } else {
                             self._successfulTileDownloads += 1
                             self._downloadedBytes += UInt64(data?.count ?? 0)
+                            self.delegate?.regionDownloader(self, didDownloadTileAt: tileCoords, dataSize: data?.count ?? 0)
                             Log.downloader.debug("Donwloaded zoom: \(tileCoords.zoom) (x:\(tileCoords.tileX),y:\(tileCoords.tileY), data.count: \(data?.count ?? 0)) \(self.downloadedTiles)/\(self.totalTilesToDownload) \(self.downloadedPercentage)%, bytes: \(self.downloadedBytes), average tile size: \(self.averageTileSizeBytes)")
                             
                         }

--- a/MapCache/Classes/RegionDownloaderDelegate.swift
+++ b/MapCache/Classes/RegionDownloaderDelegate.swift
@@ -8,27 +8,114 @@
 import Foundation
 
 ///
-/// Delegate protocol of `RegionDownloader`.
-/// Implement this protocol whenever  you use `RegionDownloader` it provides feedback while downloading a
-/// region (f.i, downloaded %) and calls back the delegate once the download finished.
+/// `RegionDownloaderDelegate` provides callbacks for monitoring the progress of a tile region download.
 ///
-/// All methods have default empty implementations, making them optional.
+/// Conform to this protocol to receive notifications about download progress, individual tile results,
+/// and lifecycle events. All methods have default empty implementations provided via a protocol extension,
+/// making each callback optional — implement only the ones you need.
+///
+/// # Usage Example
+///
+/// ```swift
+/// class MyViewController: UIViewController, RegionDownloaderDelegate {
+///
+///     func startDownload() {
+///         let downloader = RegionDownloader(forRegion: region, mapCache: cache)
+///         downloader.delegate = self
+///         downloader.start()
+///     }
+///
+///     // Update a progress bar on percentage changes.
+///     func regionDownloader(_ downloader: RegionDownloader, didDownloadPercentage percentage: Double) {
+///         DispatchQueue.main.async {
+///             self.progressView.progress = Float(percentage / 100.0)
+///         }
+///     }
+///
+///     // Show final counts when done.
+///     func regionDownloader(_ downloader: RegionDownloader, didFinishDownload tilesDownloaded: TileNumber) {
+///         DispatchQueue.main.async {
+///             self.label.text = "Done: \(tilesDownloaded) tiles"
+///         }
+///     }
+/// }
+/// ```
 ///
 public protocol RegionDownloaderDelegate: AnyObject {
 
-    /// Did download the percentage.
+    /// Called each time the overall download percentage crosses the notification threshold
+    /// (controlled by `RegionDownloader.incrementInPercentageNotification`).
+    ///
+    /// This is the main progress callback. It is not called for every tile — only when the
+    /// downloaded percentage surpasses the next multiple of `incrementInPercentageNotification`.
+    ///
+    /// - Parameters:
+    ///   - regionDownloader: The `RegionDownloader` instance that triggered the callback.
+    ///   - percentage: The current download percentage (0.0 – 100.0).
     func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadPercentage percentage: Double)
 
-    /// Did Finish Download all tiles.
+    /// Called when all tiles in the region have been processed (successfully downloaded or failed).
+    ///
+    /// This is the terminal callback. After this, no further delegate calls will be made
+    /// unless `start()` is called again.
+    ///
+    /// - Parameters:
+    ///   - regionDownloader: The `RegionDownloader` instance that triggered the callback.
+    ///   - tilesDownloaded: The total number of tiles processed (`successfulTileDownloads + failedTileDownloads`).
     func regionDownloader(_ regionDownloader: RegionDownloader, didFinishDownload tilesDownloaded: TileNumber)
 
-    /// Called before the download starts.
+    /// Called once before the download loop begins.
+    ///
+    /// Use this to prepare the UI, reset state, or log the start of a download.
+    ///
+    /// - Parameters:
+    ///   - regionDownloader: The `RegionDownloader` instance that triggered the callback.
+    ///   - totalTiles: The total number of tiles that will be attempted.
+    ///   - region: The `TileCoordsRegion` being downloaded.
+    ///   - mapCache: The `MapCacheProtocol` instance used to fetch and store tiles.
+    ///
+    /// # Example
+    /// ```swift
+    /// func regionDownloader(_ downloader: RegionDownloader, willStartDownloading totalTiles: TileNumber, region: TileCoordsRegion, mapCache: MapCacheProtocol) {
+    ///     print("Starting download of \(totalTiles) tiles at zoom \(region.zoomRange.min)–\(region.zoomRange.max)")
+    /// }
+    /// ```
     func regionDownloader(_ regionDownloader: RegionDownloader, willStartDownloading totalTiles: TileNumber, region: TileCoordsRegion, mapCache: MapCacheProtocol)
 
-    /// Called each time a tile is successfully downloaded.
+    /// Called each time a tile is successfully downloaded and cached.
+    ///
+    /// This can fire hundreds or thousands of times. Avoid performing expensive work here;
+    /// if you need to update the UI, dispatch to the main queue.
+    ///
+    /// - Parameters:
+    ///   - regionDownloader: The `RegionDownloader` instance that triggered the callback.
+    ///   - tileCoords: The coordinates (zoom, x, y) of the successfully downloaded tile.
+    ///   - dataSize: The size of the tile data in bytes.
+    ///
+    /// # Example
+    /// ```swift
+    /// func regionDownloader(_ downloader: RegionDownloader, didDownloadTileAt tileCoords: TileCoords, dataSize: Int) {
+    ///     print("✓ Tile z:\(tileCoords.zoom) x:\(tileCoords.tileX) y:\(tileCoords.tileY) — \(dataSize) bytes")
+    /// }
+    /// ```
     func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadTileAt tileCoords: TileCoords, dataSize: Int)
 
     /// Called each time a tile fails to download.
+    ///
+    /// This can fire hundreds or thousands of times. Avoid performing expensive work here;
+    /// if you need to update the UI, dispatch to the main queue.
+    ///
+    /// - Parameters:
+    ///   - regionDownloader: The `RegionDownloader` instance that triggered the callback.
+    ///   - tileCoords: The coordinates (zoom, x, y) of the tile that failed.
+    ///   - error: The error returned by the cache or network layer.
+    ///
+    /// # Example
+    /// ```swift
+    /// func regionDownloader(_ downloader: RegionDownloader, didFailToDownloadTileAt tileCoords: TileCoords, error: Error) {
+    ///     print("✗ Tile z:\(tileCoords.zoom) x:\(tileCoords.tileX) y:\(tileCoords.tileY) – \(error.localizedDescription)")
+    /// }
+    /// ```
     func regionDownloader(_ regionDownloader: RegionDownloader, didFailToDownloadTileAt tileCoords: TileCoords, error: Error)
 }
 

--- a/MapCache/Classes/RegionDownloaderDelegate.swift
+++ b/MapCache/Classes/RegionDownloaderDelegate.swift
@@ -9,14 +9,33 @@ import Foundation
 
 ///
 /// Delegate protocol of `RegionDownloader`.
-/// Implement this protocol whenever  you use `RegionDownloader` it drovides feedback while donwloading a
-/// region (f.i, downloaded %) and callsback the delegate once the download finished.
+/// Implement this protocol whenever  you use `RegionDownloader` it provides feedback while downloading a
+/// region (f.i, downloaded %) and calls back the delegate once the download finished.
 ///
-@objc public protocol RegionDownloaderDelegate: AnyObject {
-    
+/// All methods have default empty implementations, making them optional.
+///
+public protocol RegionDownloaderDelegate: AnyObject {
+
     /// Did download the percentage.
-    @objc func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadPercentage percentage: Double)
-    
+    func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadPercentage percentage: Double)
+
     /// Did Finish Download all tiles.
     func regionDownloader(_ regionDownloader: RegionDownloader, didFinishDownload tilesDownloaded: TileNumber)
+
+    /// Called before the download starts.
+    func regionDownloader(_ regionDownloader: RegionDownloader, willStartDownloading totalTiles: TileNumber, region: TileCoordsRegion, mapCache: MapCacheProtocol)
+
+    /// Called each time a tile is successfully downloaded.
+    func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadTileAt tileCoords: TileCoords, dataSize: Int)
+
+    /// Called each time a tile fails to download.
+    func regionDownloader(_ regionDownloader: RegionDownloader, didFailToDownloadTileAt tileCoords: TileCoords, error: Error)
+}
+
+public extension RegionDownloaderDelegate {
+    func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadPercentage percentage: Double) {}
+    func regionDownloader(_ regionDownloader: RegionDownloader, didFinishDownload tilesDownloaded: TileNumber) {}
+    func regionDownloader(_ regionDownloader: RegionDownloader, willStartDownloading totalTiles: TileNumber, region: TileCoordsRegion, mapCache: MapCacheProtocol) {}
+    func regionDownloader(_ regionDownloader: RegionDownloader, didDownloadTileAt tileCoords: TileCoords, dataSize: Int) {}
+    func regionDownloader(_ regionDownloader: RegionDownloader, didFailToDownloadTileAt tileCoords: TileCoords, error: Error) {}
 }


### PR DESCRIPTION


* Adds three new methods in the RegionDownload delegate: `didFailToDownloadTileAt` and `didDownloadTileAt` (Closes #29)
* Fixes issues in regiondownload stop() -- could not be resumed. 

* In the example app:
     - Makes use of the new delegate methods in the region download controller
     - Adds a pause / resume button in the region download controller
